### PR TITLE
Use explicit casts to fix mac clang c++ compiler errors.

### DIFF
--- a/include/gcc/x86_64/ck_pr.h
+++ b/include/gcc/x86_64/ck_pr.h
@@ -169,7 +169,7 @@ ck_pr_load_64_2(const uint64_t target[2], uint64_t v[2])
 CK_CC_INLINE static void
 ck_pr_load_ptr_2(void *t, void *v)
 {
-	ck_pr_load_64_2(t, v);
+	ck_pr_load_64_2((uint64_t *)t, (uint64_t *)v);
 	return;
 }
 
@@ -450,7 +450,7 @@ ck_pr_cas_64_2(uint64_t target[2], uint64_t compare[2], uint64_t set[2])
 CK_CC_INLINE static bool
 ck_pr_cas_ptr_2(void *t, void *c, void *s)
 {
-	return ck_pr_cas_64_2(t, c, s);
+	return ck_pr_cas_64_2((uint64_t *)t, (uint64_t *)c, (uint64_t *)s);
 }
 
 CK_CC_INLINE static bool
@@ -478,7 +478,7 @@ ck_pr_cas_64_2_value(uint64_t target[2],
 CK_CC_INLINE static bool
 ck_pr_cas_ptr_2_value(void *t, void *c, void *s, void *v)
 {
-	return ck_pr_cas_64_2_value(t, c, s, v);
+	return ck_pr_cas_64_2_value((uint64_t *)t, (uint64_t *)c, (uint64_t *)s, (uint64_t *)v);
 }
 
 #define CK_PR_CAS_V(S, W, T)					\


### PR DESCRIPTION
There are errors when compiling concurrency kit header files with the c++ compiler on Mac OS X.  c++ requires explicit casts from void\* variables.  This fix includes those casts.
