### PR TITLE
build: clean up extra path separator after DESTDIR

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -33,55 +33,55 @@ check: regressions
 	@echo ---[ Unit tests have completed successfully.
 
 install-headers:
-	mkdir -p $(DESTDIR)/$(HEADERS) || exit
-	cp $(SRC_DIR)/include/*.h $(DESTDIR)/$(HEADERS) || exit
-	chmod 644 $(DESTDIR)/$(HEADERS)/ck_*.h || exit
+	mkdir -p $(DESTDIR)$(HEADERS) || exit
+	cp $(SRC_DIR)/include/*.h $(DESTDIR)$(HEADERS) || exit
+	chmod 644 $(DESTDIR)$(HEADERS)/ck_*.h || exit
 	mkdir -p $(DESTDIR)$(HEADERS)/gcc || exit
-	cp -r $(SRC_DIR)/include/gcc/* $(DESTDIR)/$(HEADERS)/gcc || exit
-	cp include/ck_md.h $(DESTDIR)/$(HEADERS)/ck_md.h || exit
-	chmod 755 $(DESTDIR)/$(HEADERS)/gcc
-	chmod 644 $(DESTDIR)/$(HEADERS)/gcc/ck_*.h $(DESTDIR)/$(HEADERS)/gcc/*/ck_*.h || exit
+	cp -r $(SRC_DIR)/include/gcc/* $(DESTDIR)$(HEADERS)/gcc || exit
+	cp include/ck_md.h $(DESTDIR)$(HEADERS)/ck_md.h || exit
+	chmod 755 $(DESTDIR)$(HEADERS)/gcc
+	chmod 644 $(DESTDIR)$(HEADERS)/gcc/ck_*.h $(DESTDIR)$(HEADERS)/gcc/*/ck_*.h || exit
 	mkdir -p $(DESTDIR)$(HEADERS)/spinlock || exit
-	cp -r $(SRC_DIR)/include/spinlock/* $(DESTDIR)/$(HEADERS)/spinlock || exit
-	chmod 755 $(DESTDIR)/$(HEADERS)/spinlock
-	chmod 644 $(DESTDIR)/$(HEADERS)/spinlock/*.h || exit
+	cp -r $(SRC_DIR)/include/spinlock/* $(DESTDIR)$(HEADERS)/spinlock || exit
+	chmod 755 $(DESTDIR)$(HEADERS)/spinlock
+	chmod 644 $(DESTDIR)$(HEADERS)/spinlock/*.h || exit
 
 install-so:
-	mkdir -p $(DESTDIR)/$(LIBRARY)
-	cp src/libck.so $(DESTDIR)/$(LIBRARY)/$(LDNAME_VERSION)
-	ln -sf $(LDNAME_VERSION) $(DESTDIR)/$(LIBRARY)/$(LDNAME)
-	ln -sf $(LDNAME_VERSION) $(DESTDIR)/$(LIBRARY)/$(LDNAME_MAJOR)
-	chmod 744 $(DESTDIR)/$(LIBRARY)/$(LDNAME_VERSION)	\
-		  $(DESTDIR)/$(LIBRARY)/$(LDNAME)		\
-		  $(DESTDIR)/$(LIBRARY)/$(LDNAME_MAJOR)
+	mkdir -p $(DESTDIR)$(LIBRARY)
+	cp src/libck.so $(DESTDIR)$(LIBRARY)/$(LDNAME_VERSION)
+	ln -sf $(LDNAME_VERSION) $(DESTDIR)$(LIBRARY)/$(LDNAME)
+	ln -sf $(LDNAME_VERSION) $(DESTDIR)$(LIBRARY)/$(LDNAME_MAJOR)
+	chmod 744 $(DESTDIR)$(LIBRARY)/$(LDNAME_VERSION)	\
+		  $(DESTDIR)$(LIBRARY)/$(LDNAME)		\
+		  $(DESTDIR)$(LIBRARY)/$(LDNAME_MAJOR)
 
 install-lib:
-	mkdir -p $(DESTDIR)/$(LIBRARY)
-	cp src/libck.a $(DESTDIR)/$(LIBRARY)/libck.a
-	chmod 644 $(DESTDIR)/$(LIBRARY)/libck.a
+	mkdir -p $(DESTDIR)$(LIBRARY)
+	cp src/libck.a $(DESTDIR)$(LIBRARY)/libck.a
+	chmod 644 $(DESTDIR)$(LIBRARY)/libck.a
 
 install: all install-headers @INSTALL_LIBS@
 	$(MAKE) -C doc install
-	mkdir -p $(DESTDIR)/$(LIBRARY) || exit
-	mkdir -p $(DESTDIR)/$(PKGCONFIG_DATA) || exit
-	chmod 755 $(DESTDIR)/$(PKGCONFIG_DATA)
-	cp build/ck.pc $(DESTDIR)/$(PKGCONFIG_DATA)/ck.pc || exit
+	mkdir -p $(DESTDIR)$(LIBRARY) || exit
+	mkdir -p $(DESTDIR)$(PKGCONFIG_DATA) || exit
+	chmod 755 $(DESTDIR)$(PKGCONFIG_DATA)
+	cp build/ck.pc $(DESTDIR)$(PKGCONFIG_DATA)/ck.pc || exit
 	@echo
 	@echo
 	@echo ---[ Concurrency Kit has installed successfully.
 
 uninstall:
 	$(MAKE) -C doc uninstall
-	rm -f $(DESTDIR)/$(LIBRARY)/$(LDNAME_VERSION)	\
-	      $(DESTDIR)/$(LIBRARY)/$(LDNAME)		\
-	      $(DESTDIR)/$(LIBRARY)/$(LDNAME_MAJOR)
-	rm -f $(DESTDIR)/$(LIBRARY)/libck.so*
-	rm -f $(DESTDIR)/$(LIBRARY)/libck.a
-	rm -f $(DESTDIR)/$(HEADERS)/ck_*.h
-	rm -f $(DESTDIR)/$(HEADERS)/spinlock/*.h
-	rm -f $(DESTDIR)/$(HEADERS)/gcc/ck_*.h
-	rm -f $(DESTDIR)/$(HEADERS)/gcc/*/ck_*.h
-	rm -f $(DESTDIR)/$(PKGCONFIG_DATA)/ck.pc
+	rm -f $(DESTDIR)$(LIBRARY)/$(LDNAME_VERSION)	\
+	      $(DESTDIR)$(LIBRARY)/$(LDNAME)		\
+	      $(DESTDIR)$(LIBRARY)/$(LDNAME_MAJOR)
+	rm -f $(DESTDIR)$(LIBRARY)/libck.so*
+	rm -f $(DESTDIR)$(LIBRARY)/libck.a
+	rm -f $(DESTDIR)$(HEADERS)/ck_*.h
+	rm -f $(DESTDIR)$(HEADERS)/spinlock/*.h
+	rm -f $(DESTDIR)$(HEADERS)/gcc/ck_*.h
+	rm -f $(DESTDIR)$(HEADERS)/gcc/*/ck_*.h
+	rm -f $(DESTDIR)$(PKGCONFIG_DATA)/ck.pc
 
 clean:
 	$(MAKE) -C doc clean

--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -171,12 +171,12 @@ html:
 	done
 
 install:
-	mkdir -p $(DESTDIR)/$(MANDIR)/man3 || exit
-	cp *$(GZIP_SUFFIX) $(DESTDIR)/$(MANDIR)/man3 || exit
+	mkdir -p $(DESTDIR)$(MANDIR)/man3 || exit
+	cp *$(GZIP_SUFFIX) $(DESTDIR)$(MANDIR)/man3 || exit
 
 uninstall:
 	for target in $(OBJECTS); do 			  \
-		rm -f $(DESTDIR)/$(MANDIR)/man3/$$target$(GZIP_SUFFIX); \
+		rm -f $(DESTDIR)$(MANDIR)/man3/$$target$(GZIP_SUFFIX); \
 	done
 
 clean:


### PR DESCRIPTION
I noticed this admittedly harmless cosmetic thing when I installed ck to /usr/local. But it's trivial to fix.

before:

```
[pierce@plo-air ck]$ make DESTDIR=./pkg install
make -C doc all || exit
mkdir -p ./pkg//usr/local/include || exit
mkdir -p ./pkg//usr/local/lib
mkdir -p ./pkg//usr/local/lib
cp src/libck.so ./pkg//usr/local/lib/libck.so.0.4.4
cp src/libck.a ./pkg//usr/local/lib/libck.a
ln -sf libck.so.0.4.4 ./pkg//usr/local/lib/libck.so
chmod 644 ./pkg//usr/local/lib/libck.a
ln -sf libck.so.0.4.4 ./pkg//usr/local/lib/libck.so.0
chmod 744 ./pkg//usr/local/lib/libck.so.0.4.4   \
      ./pkg//usr/local/lib/libck.so     \
      ./pkg//usr/local/lib/libck.so.0
cp /home/pierce/scm/ck/include/*.h ./pkg//usr/local/include || exit
...
```

after:

```
[pierce@plo-air ck]$ make DESTDIR=./pkg install
make -C doc all || exit
mkdir -p ./pkg/usr/local/include || exit
mkdir -p ./pkg/usr/local/lib
mkdir -p ./pkg/usr/local/lib
cp src/libck.so ./pkg/usr/local/lib/libck.so.0.4.4
cp src/libck.a ./pkg/usr/local/lib/libck.a
ln -sf libck.so.0.4.4 ./pkg/usr/local/lib/libck.so
chmod 644 ./pkg/usr/local/lib/libck.a
ln -sf libck.so.0.4.4 ./pkg/usr/local/lib/libck.so.0
chmod 744 ./pkg/usr/local/lib/libck.so.0.4.4    \
      ./pkg/usr/local/lib/libck.so      \
      ./pkg/usr/local/lib/libck.so.0
cp /home/pierce/scm/ck/include/*.h ./pkg/usr/local/include || exit
...
```
