### PR TITLE
ck_backoff: add missing CPU stall to busy loop body.

### DIFF
--- a/include/ck_backoff.h
+++ b/include/ck_backoff.h
@@ -28,6 +28,7 @@
 #define _CK_BACKOFF_H
 
 #include <ck_cc.h>
+#include <ck_pr.h>
 
 #ifndef CK_BACKOFF_CEILING
 #define CK_BACKOFF_CEILING ((1 << 20) - 1)
@@ -48,7 +49,8 @@ ck_backoff_eb(volatile unsigned int *c)
 
 	ceiling = *c;
 
-	for (i = 0; i < ceiling; i++);
+	for (i = 0; i < ceiling; i++)
+		ck_pr_stall();
 
 	*c = ceiling <<= ceiling < CK_BACKOFF_CEILING;
 	return;


### PR DESCRIPTION
It appears this isn't a regression; ck_backoff never stalled since import. This made me question whether this was the right thing to do, but after thought, I don't see how it's not the right thing to do.