### PR TITLE
ck_ht: Fix build warnings on 32bit platforms.

### DIFF
--- a/src/ck_ht.c
+++ b/src/ck_ht.c
@@ -141,7 +141,9 @@ static struct ck_ht_map *
 ck_ht_map_create(struct ck_ht *table, uint64_t entries)
 {
 	struct ck_ht_map *map;
-	uint64_t size, n_entries, prefix;
+	uint64_t size;
+	uintptr_t prefix;
+	uint32_t n_entries;
 
 	n_entries = ck_internal_power_2(entries);
 	if (n_entries < CK_HT_BUCKET_LENGTH)


### PR DESCRIPTION
Seeing the following on an RPi2 which is 32bit ARM:
> /usr/bin/cc -D_XOPEN_SOURCE=600 -D_BSD_SOURCE -D_DEFAULT_SOURCE -std=gnu99 -pedantic -Wall -W -Wundef -Wendif-labels -Wshadow -Wpointer-arith -Wcast-align -Wcast-qual -Wwrite-strings -Wstrict-prototypes -Wmissing-prototypes -Wnested-externs -Winline -Wdisabled-optimization -fstrict-aliasing -O2 -pipe -Wno-parentheses  -fPIC -I/root/git/ck/include -I/root/git/ck/include -D__arm__ -c -o /root/git/ck/src/ck_ht.o /root/git/ck/src/ck_ht.c
> /root/git/ck/src/ck_ht.c: In function ‘ck_ht_map_create’:
> /root/git/ck/src/ck_ht.c:175:17: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
>   map->entries = (struct ck_ht_entry *)(((uintptr_t)&map[1] + prefix +

I fixed this warning by changing `prefix` to a `uintptr_t` and `n_entries` to a `uint32_t` since `prefix` is derived from it and also what `ck_internal_power_2` returns regardless.