### PR TITLE
doc fixes

### DIFF
--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -189,6 +189,14 @@ html:
 		   $(BUILD_DIR)/doc/$$target$(HTML_SUFFIX); 		\
 	done
 
+# check for entries that are missing in OBJECTS
+objcheck: all
+	for file in `ls * | egrep '(ck|CK)_' | egrep -v "($(GZIP_SUFFIX)|$(HTML_SUFFIX))$$"`; do \
+		if [ ! -f $${file}$(GZIP_SUFFIX) ]; then	\
+			echo "$$file is missing from OBJECTS" >&2;	\
+		fi;						\
+	done
+
 install:
 	mkdir -p $(DESTDIR)/$(MANDIR)/man3 || exit
 	cp *$(GZIP_SUFFIX) $(DESTDIR)/$(MANDIR)/man3 || exit

--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -199,5 +199,5 @@ uninstall:
 	done
 
 clean:
-	rm -f $(BUILD_DIR)/doc/*~ $(BUILD_DIR)/doc/*.3.gz $(BUILD_DIR)/doc/*.html
+	rm -f $(BUILD_DIR)/doc/*~ $(BUILD_DIR)/doc/*$(GZIP_SUFFIX) $(BUILD_DIR)/doc/*$(HTML_SUFFIX)
 

--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -79,6 +79,7 @@ OBJECTS=CK_ARRAY_FOREACH		\
 	ck_hs_next			\
 	ck_hs_get			\
 	ck_hs_put			\
+	ck_hs_put_unique		\
 	ck_hs_set			\
 	ck_hs_fas			\
 	ck_hs_remove			\
@@ -98,6 +99,7 @@ OBJECTS=CK_ARRAY_FOREACH		\
 	ck_rhs_next			\
 	ck_rhs_get			\
 	ck_rhs_put			\
+	ck_rhs_put_unique		\
 	ck_rhs_set			\
 	ck_rhs_fas			\
 	ck_rhs_remove			\

--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -199,6 +199,10 @@ objcheck: all
 		fi;						\
 	done
 
+# check for stale references
+refcheck:
+	@./refcheck.pl $(OBJECTS)
+
 install:
 	mkdir -p $(DESTDIR)/$(MANDIR)/man3 || exit
 	cp *$(GZIP_SUFFIX) $(DESTDIR)/$(MANDIR)/man3 || exit

--- a/doc/ck_ht_init
+++ b/doc/ck_ht_init
@@ -76,7 +76,7 @@ with using the
 .Xr ck_ht_entry_key_direct 3 ,
 .Xr ck_ht_entry_value_direct 3
 and
-.Xr ck_entry_set_direct 3
+.Xr ck_ht_entry_set_direct 3
 functions. Attempting a hash table operation with a key of value of 0 or
 UINTPTR_MAX will result in undefined behavior.
 .El

--- a/doc/refcheck.pl
+++ b/doc/refcheck.pl
@@ -1,0 +1,27 @@
+#!/usr/bin/perl
+
+use warnings;
+use strict;
+
+my @files = @ARGV;
+
+my $h;
+
+foreach my $file (@files) {
+    $h->{$file} = 1;
+}
+
+foreach my $file (@files) {
+    open(my $fh, "<", $file) or die "cannot open < $file: $!";
+    while (<$fh>) {
+        chomp;
+        if ($_ =~ /\.Xr ((ck|CK)_[a-zA-Z_]+) ([0-9])/) {
+	    my $name = $1;
+	    my $section = $3;
+	    if (!$h->{$name}) {
+		print STDERR "$file: ref to missing ${name}($section)\n";
+	    }
+        }
+    }
+    close($fh) or die("cannot close $file: $!");
+}


### PR DESCRIPTION
Hi Samy,

I've started using ck_hs/ht and when looking at the man pages I found a couple of errors in them. In this set I'm fixing these errors and also adding checks to prevent them from happening in the future.

BTW when building the HTML pages, `man2html` was always getting the `cgiurl=$$title` flag, and $$title wasn't defined anywhere. Was that intentional? I assumed it wasn't, and changed it to `cgiurl=$$target`.