### PR TITLE
arm/ck_pr: add missing conversion to CK_ namespace

### DIFF
--- a/include/gcc/arm/ck_pr.h
+++ b/include/gcc/arm/ck_pr.h
@@ -25,10 +25,10 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _CK_PR_ARM_H
-#define _CK_PR_ARM_H
+#ifndef CK_PR_ARM_H
+#define CK_PR_ARM_H
 
-#ifndef _CK_PR_H
+#ifndef CK_PR_H
 #error Do not include this file directly, use ck_pr.h
 #endif
 
@@ -55,24 +55,24 @@ ck_pr_stall(void)
 }
 
 #if defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__)
-#define __CK_ISB __asm __volatile("isb" : : "r" (0) : "memory")
-#define _CK_DMB __asm __volatile("dmb" : : "r" (0) : "memory")
-#define _CK_DSB __asm __volatile("dsb" : : "r" (0) : "memory")
+#define CK_ISB __asm __volatile("isb" : : "r" (0) : "memory")
+#define CK_DMB __asm __volatile("dmb" : : "r" (0) : "memory")
+#define CK_DSB __asm __volatile("dsb" : : "r" (0) : "memory")
 /* FreeBSD's toolchain doesn't accept dmb st, so use the opcode instead */
 #ifdef __FreeBSD__
-#define _CK_DMB_ST __asm __volatile(".word 0xf57ff05e" : : "r" (0) : "memory")
+#define CK_DMB_ST __asm __volatile(".word 0xf57ff05e" : : "r" (0) : "memory")
 #else
-#define _CK_DMB_ST __asm __volatile("dmb st" : : "r" (0) : "memory")
+#define CK_DMB_ST __asm __volatile("dmb st" : : "r" (0) : "memory")
 #endif /* __FreeBSD__ */
 #else
 /* armv6 doesn't have dsb/dmb/isb, and no way to wait only for stores */
-#define _CK_ISB \
+#define CK_ISB \
     __asm __volatile("mcr p15, 0, %0, c7, c5, 4" : : "r" (0) : "memory")
-#define _CK_DSB \
+#define CK_DSB \
     __asm __volatile("mcr p15, 0, %0, c7, c10, 4" : : "r" (0) : "memory")
-#define _CK_DMB  \
+#define CK_DMB  \
     __asm __volatile("mcr p15, 0, %0, c7, c10, 5" : : "r" (0) : "memory")
-#define _CK_DMB_ST _CK_DMB
+#define CK_DMB_ST CK_DMB
 #endif
 
 #define CK_PR_FENCE(T, I)				\
@@ -82,25 +82,25 @@ ck_pr_stall(void)
 		I;					\
 	}
 
-CK_PR_FENCE(atomic, _CK_DMB_ST)
-CK_PR_FENCE(atomic_store, _CK_DMB_ST)
-CK_PR_FENCE(atomic_load, _CK_DMB_ST)
-CK_PR_FENCE(store_atomic, _CK_DMB_ST)
-CK_PR_FENCE(load_atomic, _CK_DMB)
-CK_PR_FENCE(store, _CK_DMB_ST)
-CK_PR_FENCE(store_load, _CK_DMB_ST)
-CK_PR_FENCE(load, _CK_DMB)
-CK_PR_FENCE(load_store, _CK_DMB)
-CK_PR_FENCE(memory, _CK_DMB)
-CK_PR_FENCE(acquire, _CK_DMB)
-CK_PR_FENCE(release, _CK_DMB)
+CK_PR_FENCE(atomic, CK_DMB_ST)
+CK_PR_FENCE(atomic_store, CK_DMB_ST)
+CK_PR_FENCE(atomic_load, CK_DMB_ST)
+CK_PR_FENCE(store_atomic, CK_DMB_ST)
+CK_PR_FENCE(load_atomic, CK_DMB)
+CK_PR_FENCE(store, CK_DMB_ST)
+CK_PR_FENCE(store_load, CK_DMB_ST)
+CK_PR_FENCE(load, CK_DMB)
+CK_PR_FENCE(load_store, CK_DMB)
+CK_PR_FENCE(memory, CK_DMB)
+CK_PR_FENCE(acquire, CK_DMB)
+CK_PR_FENCE(release, CK_DMB)
 
 #undef CK_PR_FENCE
 
-#undef _CK_ISB
-#undef _CK_DSB
-#undef _CK_DMB
-#undef _CK_DMB_ST
+#undef CK_ISB
+#undef CK_DSB
+#undef CK_DMB
+#undef CK_DMB_ST
 
 #define CK_PR_LOAD(S, M, T, C, I)				\
 	CK_CC_INLINE static T					\
@@ -510,5 +510,5 @@ CK_PR_FAA(char, char, "b")
 
 #undef CK_PR_FAA
 
-#endif /* _CK_PR_ARM_H */
+#endif /* CK_PR_ARM_H */
 


### PR DESCRIPTION
Commit 554e2f08 removed underscores from _CK prefixes. It missed
the arm bits, breaking the arm build (which checks for the
non-existing _CK_PR_H). Fix it.

While at it, fix the mismatch between _CK_ISB and __CK_ISB; convert
them both to CK_ISB.

Signed-off-by: Emilio G. Cota <cota@braap.org>