### PR TITLE
Epoch proxy collection.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ regressions/ck_epoch/validate/ck_epoch_poll
 regressions/ck_epoch/validate/ck_epoch_synchronize
 regressions/ck_epoch/validate/ck_stack
 regressions/ck_epoch/validate/ck_stack_read
+regressions/ck_epc/validate/ck_epc_section
 regressions/ck_fifo/benchmark/latency
 regressions/ck_fifo/validate/ck_fifo_mpmc
 regressions/ck_fifo/validate/ck_fifo_mpmc_iterator

--- a/include/ck_epc.h
+++ b/include/ck_epc.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2015 John Esmet.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef CK_EPC_H
+#define CK_EPC_H
+
+/* 
+ * Proxy collection specialized for epoch reclamation.
+ *
+ * It works by noting the current epoch value at the time of any read section
+ * begin, incrementing the reference count for that epoch. When read sections
+ * close, they decrement the reference count and possibly move their epoch
+ * record's internal epoch value to the oldest still-referenced epoch value
+ * in the record.
+ */
+
+#include <ck_epoch.h>
+
+/*
+ * We only need at most two reference counts, since any epc
+ * record at epoch E will prevent the global epoch from advacing
+ * passed E + 1. No new read sections will ever observe E + 2.
+ */
+#define CK_EPC_GRACE 2
+
+typedef ck_epoch_cb_t ck_epc_cb_t;
+
+typedef struct ck_epc_epoch_ref {
+	unsigned int epoch_value;
+	size_t ref_count;
+} ck_epc_epoch_ref_t;
+
+typedef struct ck_epc_entry {
+	ck_epoch_entry_t entry;
+} ck_epc_entry_t;
+
+typedef struct ck_epc_record {
+	ck_epoch_record_t record;
+
+	/* Array of (epoch, refcount) pairs for this record. */
+	struct ck_epc_epoch_ref epoch_refs[CK_EPC_GRACE];
+
+	/* Number of total epc sections currently open on this record. */
+	size_t total_epoch_refs;
+} ck_epc_record_t;
+
+typedef struct ck_epc_section {
+	unsigned int epoch_idx;
+} ck_epc_section_t;
+
+typedef struct ck_epc {
+	ck_epoch_t epoch;
+} ck_epc_t;
+
+void ck_epc_init(ck_epc_t *epc);
+
+void ck_epc_register(ck_epc_t *epc, ck_epc_record_t *record);
+
+void ck_epc_unregister(ck_epc_t *epc, ck_epc_record_t *record);
+
+/*
+ * Marks the beginning of an epc-protected section.
+ */
+void ck_epc_begin(ck_epc_t *epc, ck_epc_record_t *record, ck_epc_section_t *section);
+
+/*
+ * Marks the end of an epc-protected section
+ */
+void ck_epc_end(ck_epc_t *epc, ck_epc_record_t *record, ck_epc_section_t *section);
+
+static inline void
+ck_epc_call(ck_epc_t *epc, ck_epc_record_t *record, ck_epc_entry_t *entry,
+    ck_epc_cb_t function)
+{
+
+	ck_epoch_call(&epc->epoch, &record->record, &entry->entry, function);
+
+	return;
+}
+
+static inline void
+ck_epc_barrier(ck_epc_t *epc, ck_epc_record_t *record)
+{
+
+	ck_epoch_barrier(&epc->epoch, &record->record);
+
+	return;
+}
+
+#endif /* CK_EPC_H */

--- a/include/ck_epoch.h
+++ b/include/ck_epoch.h
@@ -157,6 +157,7 @@ void ck_epoch_unregister(ck_epoch_t *, ck_epoch_record_t *);
 bool ck_epoch_poll(ck_epoch_t *, ck_epoch_record_t *);
 void ck_epoch_synchronize(ck_epoch_t *, ck_epoch_record_t *);
 void ck_epoch_barrier(ck_epoch_t *, ck_epoch_record_t *);
+void ck_epoch_dispatch(ck_epoch_record_t *record, unsigned int e);
 void ck_epoch_reclaim(ck_epoch_record_t *);
 
 #endif /* CK_EPOCH_H */

--- a/regressions/Makefile
+++ b/regressions/Makefile
@@ -7,6 +7,7 @@ DIR=array	\
     cohort	\
     epoch	\
     fifo	\
+    epc		\
     hp		\
     hs		\
     rhs		\
@@ -33,6 +34,7 @@ all:
 	$(MAKE) -C ./ck_backoff/validate all
 	$(MAKE) -C ./ck_queue/validate all
 	$(MAKE) -C ./ck_brlock/validate all
+	$(MAKE) -C ./ck_epc/validate all
 	$(MAKE) -C ./ck_ht/validate all
 	$(MAKE) -C ./ck_ht/benchmark all
 	$(MAKE) -C ./ck_brlock/benchmark all
@@ -84,6 +86,7 @@ clean:
 	$(MAKE) -C ./ck_cohort/validate clean
 	$(MAKE) -C ./ck_cohort/benchmark clean
 	$(MAKE) -C ./ck_brlock/validate clean
+	$(MAKE) -C ./ck_epc/validate clean
 	$(MAKE) -C ./ck_ht/validate clean
 	$(MAKE) -C ./ck_ht/benchmark clean
 	$(MAKE) -C ./ck_hs/validate clean

--- a/regressions/ck_epc/validate/Makefile
+++ b/regressions/ck_epc/validate/Makefile
@@ -1,0 +1,18 @@
+.PHONY: check clean distribution
+
+OBJECTS=ck_epc_section
+HALF=`expr $(CORES) / 2`
+
+all: $(OBJECTS)
+
+check: all
+	./ck_epc_section $(CORES) 1
+
+ck_epc_section: ck_epc_section.c ../../../include/ck_epc.h ../../../src/ck_epc.c ../../../include/ck_epoch.h ../../../src/ck_epoch.c
+	$(CC) $(CFLAGS) -o ck_epc_section ck_epc_section.c ../../../src/ck_epc.c ../../../src/ck_epoch.c
+
+clean:
+	rm -rf *~ *.o $(OBJECTS) *.dSYM *.exe
+
+include ../../../build/regressions.build
+CFLAGS+=$(PTHREAD_CFLAGS) -D_GNU_SOURCE

--- a/regressions/ck_epc/validate/ck_epc_section.c
+++ b/regressions/ck_epc/validate/ck_epc_section.c
@@ -1,0 +1,321 @@
+/*
+ * Copyright 2015 John Esmet.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <ck_epc.h>
+
+static ck_epc_t epc;
+static ck_epc_record_t record, record2;
+static unsigned int cleanup_calls;
+
+static void
+setup_test(void)
+{
+
+	ck_epc_init(&epc);
+	ck_epc_register(&epc, &record);
+	ck_epc_register(&epc, &record2);
+	cleanup_calls = 0;
+
+	return;
+}
+
+static void
+teardown_test(void)
+{
+
+	memset(&epc, 0, sizeof(ck_epc_t));
+	ck_epc_unregister(&epc, &record);
+	memset(&record, 0, sizeof(ck_epc_record_t));
+	memset(&record2, 0, sizeof(ck_epc_record_t));
+	cleanup_calls = 0;
+
+	return;
+}
+
+static void
+cleanup(ck_epoch_entry_t *e)
+{
+	(void) e;
+
+	cleanup_calls++;
+
+	return;
+}
+
+static void
+test_simple_read_section(void)
+{
+	ck_epc_entry_t entry;
+	ck_epc_section_t section;
+
+	memset(&entry, 0, sizeof(ck_epc_entry_t));
+	setup_test();
+
+	ck_epc_begin(&epc, &record, &section);
+	ck_epc_call(&epc, &record, &entry, cleanup);
+	assert(cleanup_calls == 0);
+
+	ck_epc_end(&epc, &record, &section);
+	ck_epc_barrier(&epc, &record);
+	assert(cleanup_calls == 1);
+
+	teardown_test();
+
+	printf("%s passed\n", __FUNCTION__);
+
+	return;
+}
+
+static void
+test_nested_read_section(void)
+{
+	ck_epc_entry_t entry1, entry2;
+	ck_epc_section_t section1, section2;
+
+	memset(&entry1, 0, sizeof(ck_epc_entry_t));
+	memset(&entry2, 0, sizeof(ck_epc_entry_t));
+	setup_test();
+
+	ck_epc_begin(&epc, &record, &section1);
+	ck_epc_call(&epc, &record, &entry1, cleanup);
+	assert(cleanup_calls == 0);
+
+	ck_epc_begin(&epc, &record, &section2);
+	ck_epc_call(&epc, &record, &entry2, cleanup);
+	assert(cleanup_calls == 0);
+
+	ck_epc_end(&epc, &record, &section2);
+	assert(cleanup_calls == 0);
+
+	ck_epc_end(&epc, &record, &section1);
+	assert(cleanup_calls == 0);
+
+	ck_epc_barrier(&epc, &record);
+	assert(cleanup_calls == 2);
+
+	teardown_test();
+
+	printf("%s passed\n", __FUNCTION__);
+
+	return;
+}
+
+struct obj {
+	ck_epc_entry_t entry;
+	unsigned int destroyed;
+};
+
+static void *
+barrier_work(void *arg)
+{
+	unsigned int *run;
+
+	run = (unsigned int *)arg;
+	while (ck_pr_load_uint(run) != 0) {
+		/*
+		 * Need to use record2, as record is local
+		 * to the test thread.
+		 */
+		ck_epc_barrier(&epc, &record2);
+		usleep(5 * 1000);
+	}
+
+	return NULL;
+}
+
+static void *
+reader_work(void *arg)
+{
+	ck_epc_record_t local_record;
+	ck_epc_section_t section;
+	struct obj *o;
+
+	ck_epc_register(&epc, &local_record);
+
+	o = (struct obj *)arg;
+
+	/*
+	 * Begin a read section. The calling thread has an open read section,
+	 * so the object should not be destroyed for the lifetime of this
+	 * thread.
+	 */
+	ck_epc_begin(&epc, &local_record, &section);
+	usleep((rand() % 100) * 1000);
+	assert(ck_pr_load_uint(&o->destroyed) == 0);
+	ck_epc_end(&epc, &local_record, &section);
+
+	ck_epc_unregister(&epc, &local_record);
+
+	return NULL;
+	
+}
+
+static void
+obj_destroy(ck_epoch_entry_t *e)
+{
+	struct obj *o;
+
+	o = (struct obj *)e;
+	ck_pr_fas_uint(&o->destroyed, 1);
+
+	return;
+}
+
+static void
+test_single_reader_with_barrier_thread(void)
+{
+	const int num_sections = 10;
+	struct obj o;
+	unsigned int run;
+	pthread_t thread;
+	ck_epc_section_t sections[num_sections];
+	int shuffled[num_sections];
+
+	run = 1;
+	memset(&o, 0, sizeof(struct obj));
+	srand(time(NULL));
+	setup_test();
+
+	if (pthread_create(&thread, NULL, barrier_work, &run) != 0) {
+		abort();
+	}
+
+	/* Start a bunch of sections. */
+	for (int i = 0; i < num_sections; i++) {
+		ck_epc_begin(&epc, &record, &sections[i]);
+		shuffled[i] = i;
+		if (i == num_sections / 2) {
+			usleep(1 * 1000);
+		}
+	}
+
+	/* Generate a shuffle. */
+	for (int i = num_sections - 1; i >= 0; i--) {
+		int k = rand() % (i + 1);
+		int tmp = shuffled[k];
+		shuffled[k] = shuffled[i];
+		shuffled[i] = tmp;
+	}
+
+	ck_epc_call(&epc, &record, &o.entry, obj_destroy);
+
+	/* Close the sections in shuffle-order. */
+	for (int i = 0; i < num_sections; i++) {
+		ck_epc_end(&epc, &record, &sections[shuffled[i]]);
+		if (i != num_sections - 1) {
+			assert(ck_pr_load_uint(&o.destroyed) == 0);
+			usleep(3 * 1000);
+		}
+	}
+
+	ck_pr_store_uint(&run, 0);
+	if (pthread_join(thread, NULL) != 0) {
+		abort();
+	}
+
+	ck_epc_barrier(&epc, &record);
+	assert(ck_pr_load_uint(&o.destroyed) == 1);
+
+	teardown_test();
+
+	printf("%s passed\n", __FUNCTION__);
+
+	return;
+}
+
+static void
+test_multiple_readers_with_barrier_thread(void)
+{
+	const int num_readers = 10;
+	struct obj o;
+	unsigned int run;
+	ck_epc_section_t section;
+	pthread_t threads[num_readers + 1];
+
+	run = 1;
+	memset(&o, 0, sizeof(struct obj));
+	memset(&section, 0, sizeof(ck_epc_section_t));
+	srand(time(NULL));
+	setup_test();
+
+	/* Create a thread to call barrier() while we create reader threads.
+	 * Each barrier will attempt to move the global epoch forward so
+	 * it will make the read section code coverage more interesting. */
+	if (pthread_create(&threads[num_readers], NULL, barrier_work, &run) != 0) {
+		abort();
+	}
+
+	ck_epc_begin(&epc, &record, &section);
+	ck_epc_call(&epc, &record, &o.entry, obj_destroy);
+
+	for (int i = 0; i < num_readers; i++) {
+		if (pthread_create(&threads[i], NULL, reader_work, &o) != 0) {
+			abort();
+		}
+	}
+
+	ck_epc_end(&epc, &record, &section);
+
+	ck_pr_store_uint(&run, 0);
+	if (pthread_join(threads[num_readers], NULL) != 0) {
+		abort();
+	}
+
+	/* After the barrier, the object should be destroyed and readers
+	 * should return. */
+	for (int i = 0; i < num_readers; i++) {
+		if (pthread_join(threads[i], NULL) != 0) {
+			abort();
+		}
+	}
+
+	teardown_test();
+
+	printf("%s passed\n", __FUNCTION__);
+
+	return;
+}
+
+int
+main(void)
+{
+
+	test_simple_read_section();
+	test_nested_read_section();
+	test_single_reader_with_barrier_thread();
+	test_multiple_readers_with_barrier_thread();
+
+	return 0;
+}

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -12,6 +12,7 @@ OBJECTS=ck_barrier_centralized.o	\
 	ck_barrier_tournament.o		\
 	ck_barrier_mcs.o		\
 	ck_epoch.o			\
+	ck_epc.o			\
 	ck_ht.o				\
 	ck_hp.o				\
 	ck_hs.o				\
@@ -31,6 +32,10 @@ ck_array.o: $(INCLUDE_DIR)/ck_array.h $(SDIR)/ck_array.c
 
 ck_epoch.o: $(INCLUDE_DIR)/ck_epoch.h $(SDIR)/ck_epoch.c $(INCLUDE_DIR)/ck_stack.h
 	$(CC) $(CFLAGS) -c -o $(TARGET_DIR)/ck_epoch.o $(SDIR)/ck_epoch.c
+
+
+ck_epc.o: $(INCLUDE_DIR)/ck_epc.h $(SDIR)/ck_epc.c
+	$(CC) $(CFLAGS) -c -o $(TARGET_DIR)/ck_epc.o $(SDIR)/ck_epc.c
 
 ck_hs.o: $(INCLUDE_DIR)/ck_hs.h $(SDIR)/ck_hs.c
 	$(CC) $(CFLAGS) -c -o $(TARGET_DIR)/ck_hs.o $(SDIR)/ck_hs.c

--- a/src/ck_epc.c
+++ b/src/ck_epc.c
@@ -108,6 +108,15 @@ ck_epc_begin(ck_epc_t *epc, ck_epc_record_t *record, ck_epc_section_t *section)
 	epoch_idx = epoch % CK_EPC_GRACE;
 	ref = &record->epoch_refs[epoch_idx];
 	if (ref->ref_count == 0) {
+		/*
+		 * We are about to reference a new epoch.
+		 *
+		 * It is now safe to dispatch callbacks for on the deferral
+		 * stack for `epoch % CK_EPOCH_LENGTH' (see implementation),
+		 * since the last epoch to be allocated on that portion of the
+		 * ring was at least 2 epochs older.
+		 */
+		ck_epoch_dispatch(&record->record, epoch);
 		ref->epoch_value = epoch;
 		ref->ref_count = 1;
 	} else {

--- a/src/ck_epc.c
+++ b/src/ck_epc.c
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2015 John Esmet.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include <ck_epc.h>
+
+void
+ck_epc_init(ck_epc_t *epc)
+{
+
+	ck_epoch_init(&epc->epoch);
+
+	return;
+}
+
+void
+ck_epc_register(ck_epc_t *epc, ck_epc_record_t *record)
+{
+
+	memset(record, 0, sizeof(ck_epc_record_t));
+	ck_epoch_register(&epc->epoch, &record->record);
+
+	return;
+}
+
+void
+ck_epc_unregister(ck_epc_t *epc, ck_epc_record_t *record)
+{
+
+	ck_epoch_unregister(&epc->epoch, &record->record);
+	memset(record, 0, sizeof(ck_epc_record_t));
+
+	return;
+}
+
+static inline bool
+modular_less_than(unsigned int a, unsigned int b)
+{
+
+	return (int)(a - b) < 0;
+}
+
+static ck_epc_epoch_ref_t *
+get_oldest_referenced_epoch_ref(ck_epc_record_t *record)
+{
+	ck_epc_epoch_ref_t *oldest;
+
+	oldest = NULL;
+	for (unsigned int i = 0; i < CK_EPC_GRACE; i++) {
+		ck_epc_epoch_ref_t *ref;
+
+		ref = &record->epoch_refs[i];
+		if (ref->ref_count == 0) {
+			continue;
+		}
+
+		if (oldest == NULL ||
+		    modular_less_than(ref->epoch_value, oldest->epoch_value)) {
+			oldest = ref;
+		}
+	}
+
+	return oldest;
+}
+
+void
+ck_epc_begin(ck_epc_t *epc, ck_epc_record_t *record, ck_epc_section_t *section)
+{
+	unsigned int epoch;
+	unsigned int epoch_idx;
+	ck_epc_epoch_ref_t *ref;
+
+	/* Begin this record's epoch section if this is the first ref. */
+	record->total_epoch_refs++;
+	if (record->total_epoch_refs == 1) {
+		ck_epoch_begin(&epc->epoch, &record->record);
+	}
+
+	/* Observe the current epoch value. */
+	epoch = ck_pr_load_uint(&epc->epoch.epoch);
+
+	epoch_idx = epoch % CK_EPC_GRACE;
+	ref = &record->epoch_refs[epoch_idx];
+	if (ref->ref_count == 0) {
+		ref->epoch_value = epoch;
+		ref->ref_count = 1;
+	} else {
+		assert(ref->epoch_value == epoch);
+		ref->ref_count++;
+	}
+
+	section->epoch_idx = epoch_idx;
+
+	return;
+}
+
+void
+ck_epc_end(ck_epc_t *epc, ck_epc_record_t *record, ck_epc_section_t *section)
+{
+	ck_epc_epoch_ref_t *ref, *oldest_ref;
+
+	assert(record->total_epoch_refs > 0);
+
+	ref = &record->epoch_refs[section->epoch_idx];
+	assert(ref->ref_count > 0);
+
+	ref->ref_count--;
+	if (ref->ref_count == 0) {
+		unsigned int epoch;
+
+		/*
+		 * Find the next oldest epoch value with a non-zero ref count.
+		 *
+		 * If there are no more referenced epochs, then the oldest
+		 * epoch is the current epoch, and we won't change the current
+		 * epoch value at all.
+		 */
+		epoch = ck_pr_load_uint(&record->record.epoch);
+		oldest_ref = get_oldest_referenced_epoch_ref(record);
+		if (oldest_ref != NULL &&
+		    modular_less_than(epoch, oldest_ref->epoch_value)) {
+			/* Update this record's epoch value to match the oldest value. */
+			ck_pr_fas_uint(&record->record.epoch, oldest_ref->epoch_value);
+		}
+	}
+
+	/* End this record's epoch section if there are no more references. */
+	record->total_epoch_refs--;
+	if (record->total_epoch_refs == 0) {
+		ck_epoch_end(&epc->epoch, &record->record);
+	}
+
+	return;
+}

--- a/src/ck_epoch.c
+++ b/src/ck_epoch.c
@@ -253,7 +253,7 @@ ck_epoch_scan(struct ck_epoch *global,
 	return NULL;
 }
 
-static void
+void
 ck_epoch_dispatch(struct ck_epoch_record *record, unsigned int e)
 {
 	unsigned int epoch = e & (CK_EPOCH_LENGTH - 1);


### PR DESCRIPTION
Open for comments! I made a thing that attaches a reference count to epoch read sections. The idea here is that you can use a single thread-local epoch record and declare read sections as necessary. In practice, I'll use this to attach read sections to objects whose lifetime is managed asynchronously on an event base.