### PR TITLE
ck_sequence: relax sequence increment from atomic to regular store

### DIFF
--- a/include/ck_sequence.h
+++ b/include/ck_sequence.h
@@ -101,7 +101,7 @@ ck_sequence_write_begin(struct ck_sequence *sq)
 	 * Increment the sequence to an odd number to indicate
 	 * the beginning of a write update.
 	 */
-	ck_pr_inc_uint(&sq->sequence);
+	sq->sequence++;
 	ck_pr_fence_store();
 	return;
 }
@@ -118,7 +118,7 @@ ck_sequence_write_end(struct ck_sequence *sq)
 	 * completion of a write update.
 	 */
 	ck_pr_fence_store();
-	ck_pr_inc_uint(&sq->sequence);
+	sq->sequence++;
 	return;
 }
 


### PR DESCRIPTION
The atomicity of the sequence number's increment is unnecessary, since
there should be only one writer at any given time. Fix it by changing
it for a regular increment + store.

Signed-off-by: Emilio G. Cota <cota@braap.org>