### PR TITLE
Fix build issue with LLVM/CLang 3.8

### DIFF
--- a/include/gcc/x86_64/ck_pr.h
+++ b/include/gcc/x86_64/ck_pr.h
@@ -191,7 +191,7 @@ ck_pr_load_64_2(const uint64_t target[2], uint64_t v[2])
 CK_CC_INLINE static void
 ck_pr_load_ptr_2(const void *t, void *v)
 {
-	ck_pr_load_64_2(t, v);
+	ck_pr_load_64_2((const uint64_t *)t, (uint64_t *)v);
 	return;
 }
 
@@ -472,7 +472,7 @@ ck_pr_cas_64_2(uint64_t target[2], uint64_t compare[2], uint64_t set[2])
 CK_CC_INLINE static bool
 ck_pr_cas_ptr_2(void *t, void *c, void *s)
 {
-	return ck_pr_cas_64_2(t, c, s);
+	return ck_pr_cas_64_2((uint64_t *)t, (uint64_t *)c, (uint64_t *)s);
 }
 
 CK_CC_INLINE static bool
@@ -500,7 +500,7 @@ ck_pr_cas_64_2_value(uint64_t target[2],
 CK_CC_INLINE static bool
 ck_pr_cas_ptr_2_value(void *t, void *c, void *s, void *v)
 {
-	return ck_pr_cas_64_2_value(t, c, s, v);
+	return ck_pr_cas_64_2_value((uint64_t *)t, (uint64_t *)c, (uint64_t *)s, (uint64_t *)v);
 }
 
 #define CK_PR_CAS_V(S, W, T)					\


### PR DESCRIPTION
Clang 3.8 forbids automatic casting from 'void *' to 'uint64_t[]'.

OS: OS X 10.10
Compiler: LLVM/Clang 3.8.0 (trunk 243734)
CPU: 2,5 GHz Intel Core i7