### PR TITLE
CK_PR_ACCESS:  use __typeof__ instead of typeof

### DIFF
--- a/include/ck_limits.h
+++ b/include/ck_limits.h
@@ -26,6 +26,20 @@
 
 #if defined(__linux__) && defined(__KERNEL__)
 #include <linux/kernel.h>
+
+#ifndef UINT8_MAX
+#define UINT8_MAX ((u8)(~0U))
+#endif
+#ifndef UINT16_MAX
+#define UINT16_MAX USHRT_MAX
+#endif
+#ifndef UINT32_MAX
+#define UINT32_MAX ULONG_MAX
+#endif
+#ifndef UINT64_MAX
+#define UINT64_MAX ULLONG_MAX
+#endif
+
 #else
 #include <limits.h>
 #endif /* __linux__ && __KERNEL__ */

--- a/include/gcc/arm/ck_pr.h
+++ b/include/gcc/arm/ck_pr.h
@@ -217,12 +217,12 @@ ck_pr_cas_64_value(uint64_t *target, uint64_t compare, uint64_t set, uint64_t *v
 CK_CC_INLINE static bool
 ck_pr_cas_ptr_2_value(void *target, void *compare, void *set, void *value)
 {
-	uint32_t *_compare = compare;
-	uint32_t *_set = set;
+	uint32_t *_compare = (uint32_t *) compare;
+	uint32_t *_set = (uint32_t *) set;
 	uint64_t __compare = ((uint64_t)_compare[0]) | ((uint64_t)_compare[1] << 32);
 	uint64_t __set = ((uint64_t)_set[0]) | ((uint64_t)_set[1] << 32);
 
-	return (ck_pr_cas_64_value(target, __compare, __set, value));
+	return (ck_pr_cas_64_value((uint64_t *)target, __compare, __set, (uint64_t *)value));
 }
 
 
@@ -253,11 +253,11 @@ ck_pr_cas_64(uint64_t *target, uint64_t compare, uint64_t set)
 CK_CC_INLINE static bool
 ck_pr_cas_ptr_2(void *target, void *compare, void *set)
 {
-	uint32_t *_compare = compare;
-	uint32_t *_set = set;
+	uint32_t *_compare = (uint32_t *)compare;
+	uint32_t *_set = (uint32_t *)set;
 	uint64_t __compare = ((uint64_t)_compare[0]) | ((uint64_t)_compare[1] << 32);
 	uint64_t __set = ((uint64_t)_set[0]) | ((uint64_t)_set[1] << 32);
-	return (ck_pr_cas_64(target, __compare, __set));
+	return (ck_pr_cas_64((uint64_t *)target, __compare, __set));
 }
 
 #endif

--- a/include/gcc/ck_pr.h
+++ b/include/gcc/ck_pr.h
@@ -53,7 +53,7 @@ ck_pr_barrier(void)
  */
 #include "ck_f_pr.h"
 
-#define CK_PR_ACCESS(x) (*(volatile typeof(x) *)&(x))
+#define CK_PR_ACCESS(x) (*(volatile __typeof__(x) *)&(x))
 
 #define CK_PR_LOAD(S, M, T)		 			\
 	CK_CC_INLINE static T					\


### PR DESCRIPTION
this makes ck_pr.h safe to include in c++ with -std=c++11

all gcc+clang tests pass on x86-4cores, amd64-2cores, i.mx6-4cores, rpi2-4cores
