### PR TITLE
ck_limits.h: assure UINT*_MAX ff are available in-kernel

### DIFF
--- a/include/ck_limits.h
+++ b/include/ck_limits.h
@@ -26,6 +26,20 @@
 
 #if defined(__linux__) && defined(__KERNEL__)
 #include <linux/kernel.h>
+
+#ifndef UINT8_MAX
+#define UINT8_MAX ((u8)(~0U))
+#endif
+#ifndef UINT16_MAX
+#define UINT16_MAX USHRT_MAX
+#endif
+#ifndef UINT32_MAX
+#define UINT32_MAX UINT_MAX
+#endif
+#ifndef UINT64_MAX
+#define UINT64_MAX ULLONG_MAX
+#endif
+
 #else
 #include <limits.h>
 #endif /* __linux__ && __KERNEL__ */


### PR DESCRIPTION
this should work back to at least 3.5 kernels