### PR TITLE
Hashtable: actually make sure to call user-specified hash function. With new regression test.

### DIFF
--- a/src/ck_ht.c
+++ b/src/ck_ht.c
@@ -112,7 +112,7 @@ ck_ht_hash(struct ck_ht_hash *h,
     uint16_t key_length)
 {
 
-	h->value = MurmurHash64A(key, key_length, table->seed);
+	table->h(h, key, key_length, table->seed);
 	return;
 }
 


### PR DESCRIPTION
There were one place (`ck_ht_hash()` function) that did not use user-specified hash function.
First commit adds a check whether user-specified hash function is actually used,
and second commit then fixes the failing test.