### PR TITLE
use __restrict__ under GCC to support both C++ and C

### DIFF
--- a/include/gcc/ck_cc.h
+++ b/include/gcc/ck_cc.h
@@ -55,7 +55,7 @@
 #endif
 
 #define CK_CC_FORCE_INLINE CK_CC_UNUSED __attribute__((always_inline)) inline
-#define CK_CC_RESTRICT restrict
+#define CK_CC_RESTRICT __restrict__
 
 /*
  * Packed attribute.


### PR DESCRIPTION
GCC supports the __restrict__ qualifier in lieu of the restrict keyword (which is not available in C++). This PR redefines CK_CC_RESTRICT to use the underscored variant to enable compilation of programs using concurrencykit with G++.