### PR TITLE
Add AArch64 timer support to rdtsc().

### DIFF
--- a/regressions/common.h
+++ b/regressions/common.h
@@ -442,6 +442,11 @@ rdtsc(void)
 	} while (snapshot != high);
 
 	return (((uint64_t)high << 32) | low);
+#elif defined(__aarch64__)
+	uint64_t r;
+
+	__asm __volatile__ ("mrs %0, cntvct_el0" : "=r" (r) : : "memory");
+	return r;
 #else
 	return 0;
 #endif


### PR DESCRIPTION
Add support for RDTSC-like timer on AArch64. This is only used by the
internal regression/benchmark test suite.