### PR TITLE
Add casts, drop 0-sized arrays, to please C++

### DIFF
--- a/include/ck_array.h
+++ b/include/ck_array.h
@@ -37,7 +37,7 @@
 struct _ck_array {
 	unsigned int n_committed;
 	unsigned int length;
-	void *values[];
+	void *values[1];
 };
 
 struct ck_array {

--- a/include/ck_bitmap.h
+++ b/include/ck_bitmap.h
@@ -116,7 +116,7 @@
 
 struct ck_bitmap {
 	unsigned int n_bits;
-	unsigned int map[];
+	unsigned int map[1];
 };
 typedef struct ck_bitmap ck_bitmap_t;
 
@@ -142,7 +142,7 @@ CK_CC_INLINE static unsigned int
 ck_bitmap_size(unsigned int n_bits)
 {
 
-	return ck_bitmap_base(n_bits) + sizeof(struct ck_bitmap);
+	return offsetof(struct ck_bitmap, map[CK_BITMAP_BLOCKS(n_bits) * sizeof(unsigned int)]);
 }
 
 /*

--- a/include/ck_bytelock.h
+++ b/include/ck_bytelock.h
@@ -81,7 +81,7 @@ ck_bytelock_init(struct ck_bytelock *bytelock)
 CK_CC_INLINE static void
 ck_bytelock_write_lock(struct ck_bytelock *bytelock, unsigned int slot)
 {
-	CK_BYTELOCK_TYPE *readers = (void *)bytelock->readers;
+	CK_BYTELOCK_TYPE *readers = (CK_BYTELOCK_TYPE *)bytelock->readers;
 	unsigned int i;
 
 	/* Announce upcoming writer acquisition. */

--- a/include/ck_stack.h
+++ b/include/ck_stack.h
@@ -152,7 +152,7 @@ ck_stack_batch_pop_upmc(struct ck_stack *target)
 {
 	struct ck_stack_entry *entry;
 
-	entry = ck_pr_fas_ptr(&target->head, NULL);
+	entry = (struct ck_stack_entry *)ck_pr_fas_ptr(&target->head, NULL);
 	ck_pr_fence_load();
 	return entry;
 }
@@ -276,7 +276,7 @@ ck_stack_push_mpnc(struct ck_stack *target, struct ck_stack_entry *entry)
 
 	entry->next = NULL;
 	ck_pr_fence_store_atomic();
-	stack = ck_pr_fas_ptr(&target->head, entry);
+	stack = (struct ck_stack_entry *)ck_pr_fas_ptr(&target->head, entry);
 	ck_pr_store_ptr(&entry->next, stack);
 	ck_pr_fence_store();
 

--- a/include/spinlock/clh.h
+++ b/include/spinlock/clh.h
@@ -78,7 +78,7 @@ ck_spinlock_clh_lock(struct ck_spinlock_clh **queue, struct ck_spinlock_clh *thr
 	 * Mark current request as last request. Save reference to previous
 	 * request.
 	 */
-	previous = ck_pr_fas_ptr(queue, thread);
+	previous = (struct ck_spinlock_clh *)ck_pr_fas_ptr(queue, thread);
 	thread->previous = previous;
 
 	/* Wait until previous thread is done with lock. */

--- a/include/spinlock/hclh.h
+++ b/include/spinlock/hclh.h
@@ -86,7 +86,7 @@ ck_spinlock_hclh_lock(struct ck_spinlock_hclh **glob_queue,
 	ck_pr_fence_store_atomic();
 
 	/* Mark current request as last request. Save reference to previous request. */
-	previous = ck_pr_fas_ptr(local_queue, thread);
+	previous = (struct ck_spinlock_hclh *)ck_pr_fas_ptr(local_queue, thread);
 	thread->previous = previous;
 
 	/* Wait until previous thread from the local queue is done with lock. */
@@ -103,7 +103,7 @@ ck_spinlock_hclh_lock(struct ck_spinlock_hclh **glob_queue,
 
 	/* Now we need to splice the local queue into the global queue. */
 	local_tail = ck_pr_load_ptr(local_queue);
-	previous = ck_pr_fas_ptr(glob_queue, local_tail);
+	previous = (struct ck_spinlock_hclh *)ck_pr_fas_ptr(glob_queue, local_tail);
 
 	ck_pr_store_uint(&local_tail->splice, true);
 

--- a/include/spinlock/mcs.h
+++ b/include/spinlock/mcs.h
@@ -97,7 +97,7 @@ ck_spinlock_mcs_lock(struct ck_spinlock_mcs **queue,
 	 * returns NULL, it means the queue was empty. If the queue was empty,
 	 * then the operation is complete.
 	 */
-	previous = ck_pr_fas_ptr(queue, node);
+	previous = (struct ck_spinlock_mcs *)ck_pr_fas_ptr(queue, node);
 	if (previous != NULL) {
 		/*
 		 * Let the previous lock holder know that we are waiting on


### PR DESCRIPTION
Add casts from void* to specific pointer types, in header files.  Avoid empty arrays.  These changes were sufficient to get a g++ compiler (gcc version 4.8.4 (Ubuntu 4.8.4-2ubuntu1~14.04)) to compile a source file that included every ck header file, other than the architecture-specific ones.