### PR TITLE
ck_queue: fix logic inversion in CK_STAILQ_CONCAT.

### DIFF
--- a/include/ck_queue.h
+++ b/include/ck_queue.h
@@ -235,7 +235,7 @@ struct {								\
  * Singly-linked Tail queue functions.
  */
 #define	CK_STAILQ_CONCAT(head1, head2) do {					\
-	if ((head2)->stqh_first == NULL) {					\
+	if ((head2)->stqh_first != NULL) {					\
 		ck_pr_store_ptr((head1)->stqh_last, (head2)->stqh_first);	\
 		ck_pr_fence_store();						\
 		(head1)->stqh_last = (head2)->stqh_last;			\


### PR DESCRIPTION
old version would only attempt to append `head2` to `head1` if `head2` was empty.