### PR TITLE
Quiet implicit fallthrough compiler warnings.

### DIFF
--- a/src/ck_ht_hash.h
+++ b/src/ck_ht_hash.h
@@ -155,7 +155,9 @@ static inline void MurmurHash3_x86_32 ( const void * key, int len,
   switch(len & 3)
   {
   case 3: k1 ^= tail[2] << 16;
+  /* fall through */
   case 2: k1 ^= tail[1] << 8;
+  /* fall through */
   case 1: k1 ^= tail[0];
           k1 *= c1; k1 = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
   };
@@ -204,11 +206,17 @@ static inline uint64_t MurmurHash64A ( const void * key, int len, uint64_t seed 
   switch(len & 7)
   {
   case 7: h ^= (uint64_t)(data2[6]) << 48;
+  /* fall through */
   case 6: h ^= (uint64_t)(data2[5]) << 40;
+  /* fall through */
   case 5: h ^= (uint64_t)(data2[4]) << 32;
+  /* fall through */
   case 4: h ^= (uint64_t)(data2[3]) << 24;
+  /* fall through */
   case 3: h ^= (uint64_t)(data2[2]) << 16;
+  /* fall through */
   case 2: h ^= (uint64_t)(data2[1]) << 8;
+  /* fall through */
   case 1: h ^= (uint64_t)(data2[0]);
           h *= m;
   };
@@ -257,7 +265,9 @@ static inline uint64_t MurmurHash64B ( const void * key, int len, uint64_t seed 
   switch(len)
   {
   case 3: h2 ^= ((const unsigned char*)data)[2] << 16;
+  /* fall through */
   case 2: h2 ^= ((const unsigned char*)data)[1] << 8;
+  /* fall through */
   case 1: h2 ^= ((const unsigned char*)data)[0];
       h2 *= m;
   };


### PR DESCRIPTION
Annotate fall through cases in switch statements where that behavior is
desirable to quiet compiler warnings with the -Wimplicit-fallthrough
flag. The annotation format used is supported by both GCC and Clang.

Fixes #108.