### PR TITLE
allow ck_epoch_poll to populate a deferred stack of callbacks

### DIFF
--- a/include/ck_epoch.h
+++ b/include/ck_epoch.h
@@ -266,6 +266,7 @@ void ck_epoch_register(ck_epoch_t *, ck_epoch_record_t *, void *);
 void ck_epoch_unregister(ck_epoch_record_t *);
 
 bool ck_epoch_poll(ck_epoch_record_t *);
+bool ck_epoch_poll_deferred(struct ck_epoch_record *record, ck_stack_t *deferred);
 void ck_epoch_synchronize(ck_epoch_record_t *);
 void ck_epoch_synchronize_wait(ck_epoch_t *, ck_epoch_wait_cb_t *, void *);
 void ck_epoch_barrier(ck_epoch_record_t *);


### PR DESCRIPTION
On FreeBSD in epoch(9) records are pcpu. In order to safely access them a thread disables preemption. The problem with ck_poll executing the callback directly is that we need to access the list with preemption disabled but we can't actually execute the callbacks with preemption disabled. This should populate a deferred stack which the caller can then go and execute after re-enabling preemption. I plan on committing something like this to FreeBSD tomorrowish. 