### PR TITLE
add CK_SLIST_INSERT_PREVPTR and CK_SLIST_REMOVE_PREVPTR

### DIFF
--- a/include/ck_queue.h
+++ b/include/ck_queue.h
@@ -180,6 +180,12 @@ struct {									\
 	ck_pr_store_ptr(&(head)->cslh_first, elm);				\
 } while (0)
 
+#define	CK_SLIST_INSERT_PREVPTR(prevp, slistelm, elm, field) do {		\
+	(elm)->field.csle_next = (slistelm);					\
+	ck_pr_fence_store();							\
+	ck_pr_store_ptr(prevp, elm);						\
+} while (0)
+
 #define CK_SLIST_REMOVE_AFTER(elm, field) do {					\
 	ck_pr_store_ptr(&(elm)->field.csle_next,					\
 	    (elm)->field.csle_next->field.csle_next);				\
@@ -199,6 +205,10 @@ struct {									\
 #define	CK_SLIST_REMOVE_HEAD(head, field) do {					\
 	ck_pr_store_ptr(&(head)->cslh_first,					\
 		(head)->cslh_first->field.csle_next);				\
+} while (0)
+
+#define CK_SLIST_REMOVE_PREVPTR(prevp, elm, field) do {				\
+	ck_pr_store_ptr(prevptr, (elm)->field.csle_next);			\
 } while (0)
 
 #define CK_SLIST_MOVE(head1, head2, field) do {					\


### PR DESCRIPTION
These new macros are very convenient for modifying a SLIST after
using CK_SLIST_FOREACH_PREVPTR to find an element to remove
or a position to insert.

FreeBSD sys/queue.h already has SLIST_REMOVE_PREVPTR.

I would like to use the new macros in a change that I am planning
for FreeBSD kernel:
https://reviews.freebsd.org/D16016
https://reviews.freebsd.org/D15905