### PR TITLE
Fix configure on FreeBSD powerpc64

### DIFF
--- a/configure
+++ b/configure
@@ -383,11 +383,18 @@ assert "$SYSTEM" "$SYSTEM" "unsupported"
 CORES=${CORES:-${DCORES}}
 printf "Detecting machine architecture..."
 if test "x$PLATFORM" = "x"; then
-	PLATFORM=`uname -m 2> /dev/null`
+	case $SYSTEM in
+		"freebsd")
+			PLATFORM=`uname -p 2> /dev/null`
+			;;
+		*)
+			PLATFORM=`uname -m 2> /dev/null`
+			;;
+	esac
 fi
 
 case $PLATFORM in
-	"macppc"|"Power Macintosh"|"powerpc")
+	"macppc"|"Power Macintosh"|"powerpc"|"powerpcspe")
 		RTM_ENABLE="CK_MD_RTM_DISABLE"
 		LSE_ENABLE="CK_MD_LSE_DISABLE"
 		MM="${MM:-"CK_MD_RMO"}"
@@ -475,19 +482,22 @@ case $PLATFORM in
 				;;
 		esac
 		;;
-	"ppc64"|"ppc64le")
+	"ppc64"|"ppc64le"|"powerpc64")
 		RTM_ENABLE="CK_MD_RTM_DISABLE"
 		LSE_ENABLE="CK_MD_LSE_DISABLE"
 		MM="${MM:-"CK_MD_RMO"}"
 		PLATFORM=ppc64
 		ENVIRONMENT=64
 		;;
-	arm|armv6l|armv7l)
-		if test "$PLATFORM" = "armv6l"; then
-			CFLAGS="$CFLAGS -march=armv6k";
-		elif test "$PLATFORM" = "armv7l"; then
-			CFLAGS="$CFLAGS -march=armv7-a";
-		fi
+	arm|armv6|armv6l|armv7|armv7l)
+		case "$PLATFORM" in
+			"armv6"|"armv6l")
+				CFLAGS="$CFLAGS -march=armv6k";
+				;;
+			"armv7"|"armv7l")
+				CFLAGS="$CFLAGS -march=armv7-a";
+				;;
+		esac
 		RTM_ENABLE="CK_MD_RTM_DISABLE"
 		LSE_ENABLE="CK_MD_LSE_DISABLE"
 		MM="${MM:-"CK_MD_RMO"}"


### PR DESCRIPTION
powerpc64 is a sub type of powerpc on FreeBSD (i.e. uname -m returns 'powerpc' on both 32b and 64b ppc systems).

I fixed up ppc, arm, but this will have some additional implications for mips and riscv if we ever add those (see arch(7))