### PR TITLE
Basic fixes for Windows compatibility

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -36,12 +36,12 @@ install-headers:
 	mkdir -p $(DESTDIR)/$(HEADERS) || exit
 	cp $(SRC_DIR)/include/*.h $(DESTDIR)/$(HEADERS) || exit
 	chmod 644 $(DESTDIR)/$(HEADERS)/ck_*.h || exit
-	mkdir -p $(DESTDIR)$(HEADERS)/gcc || exit
+	mkdir -p $(DESTDIR)/$(HEADERS)/gcc || exit
 	cp -r $(SRC_DIR)/include/gcc/* $(DESTDIR)/$(HEADERS)/gcc || exit
 	cp include/ck_md.h $(DESTDIR)/$(HEADERS)/ck_md.h || exit
 	chmod 755 $(DESTDIR)/$(HEADERS)/gcc
 	chmod 644 $(DESTDIR)/$(HEADERS)/gcc/ck_*.h $(DESTDIR)/$(HEADERS)/gcc/*/ck_*.h || exit
-	mkdir -p $(DESTDIR)$(HEADERS)/spinlock || exit
+	mkdir -p $(DESTDIR)/$(HEADERS)/spinlock || exit
 	cp -r $(SRC_DIR)/include/spinlock/* $(DESTDIR)/$(HEADERS)/spinlock || exit
 	chmod 755 $(DESTDIR)/$(HEADERS)/spinlock
 	chmod 644 $(DESTDIR)/$(HEADERS)/spinlock/*.h || exit

--- a/configure
+++ b/configure
@@ -369,10 +369,14 @@ case "$SYSTEM" in
 		SYSTEM=mingw32
 		LDFLAGS="-mthreads $LDFLAGS"
 		;;
-  CYGWIN_NT*)
-    SYSTEM=cygwin
-    LDFLAGS="-mthreads $LDFLAGS"
-    ;;
+	MINGW64*)
+		SYSTEM=mingw64
+		LDFLAGS="-mthreads $LDFLAGS"
+		;;
+	CYGWIN_NT*)
+		SYSTEM=cygwin
+		LDFLAGS="-mthreads $LDFLAGS"
+		;;
 	*)
 		SYSTEM=
 		;;

--- a/regressions/ck_bitmap/validate/serial.c
+++ b/regressions/ck_bitmap/validate/serial.c
@@ -159,7 +159,7 @@ test_init(bool init)
 
 	bytes = ck_bitmap_size(length);
 	bitmap = malloc(bytes);
-	memset(bitmap, random(), bytes);
+	memset(bitmap, common_rand(), bytes);
 
 	ck_bitmap_init(bitmap, length, init);
 
@@ -188,7 +188,7 @@ random_init(void)
 	ck_bitmap_init(bitmap, length, false);
 
 	for (i = 0; i < length; i++) {
-		if (random() & 1) {
+		if (common_rand() & 1) {
 			ck_bitmap_set(bitmap, i);
 		}
 	}
@@ -259,7 +259,7 @@ random_test(unsigned int seed)
 	ck_bitmap_t *x, *x_copy, *y;
 	unsigned int i;
 
-	srandom(seed);
+	common_srand(seed);
 
 	test_init(false);
 	test_init(true);


### PR DESCRIPTION
Basic modifications to configure, Makefile.in, and regressions testing for compatibility with Windows

Added support for MINGW64 system, fixes to typos within Makefile.in, and a change to ck_bitmap's regression to use the correct rand() function based on platform

Specifics:

    configure:
    +       MINGW64*)
    +               SYSTEM=mingw64
    +               LDFLAGS="-mthreads $LDFLAGS"
    +               ;;

This is all that is needed for compilation with MSYS2 and MinGW64. Extensive testing has not been done, however, as I'm not entirely sure what to look for, as only ck_ec triggered a failed assertion (No ck_ec ops for this platform)

    regressions/ck_bitmap/validate/serial.c:
    -       memset(bitmap, random(), bytes);
    +       memset(bitmap, common_rand(), bytes);
     ... more of the same replacement

Ensure the right function is called based on the platform

    Makefile.in:
    -       mkdir -p $(DESTDIR)$(HEADERS)/gcc || exit
    +       mkdir -p $(DESTDIR)/$(HEADERS)/gcc || exit
    ...
    -       mkdir -p $(DESTDIR)$(HEADERS)/spinlock || exit
    +       mkdir -p $(DESTDIR)/$(HEADERS)/spinlock || exit

The wrong directories were being created, which meant the following ```cp``` commands would fail. I believe this was simply a typo, and the Linux version of ```cp``` command had no issue creating a directory, or DESTDIR always had a trailing '/'
