### PR TITLE
Fix 12 dependency issues with auto header dependencies

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -66,3 +66,15 @@ ck_barrier_mcs.o: $(SDIR)/ck_barrier_mcs.c
 clean:
 	rm -rf $(TARGET_DIR)/*.dSYM $(TARGET_DIR)/*~ $(TARGET_DIR)/*.o \
 		$(OBJECTS) $(TARGET_DIR)/libck.a $(TARGET_DIR)/libck.so
+	rm -rf $(AUTODEPS)	
+
+# create a list of auto dependencies
+AUTODEPS:= $(patsubst %.o,$(TARGET_DIR)/%.d, $(OBJECTS))
+
+# include by auto dependencies
+-include $(AUTODEPS)
+
+%.o: $(TARGET_DIR)/%.d
+
+$(TARGET_DIR)/%.d: $(SDIR)/%.c
+	$(CC) $(CFLAGS) -MM -MP -MF $@ $<


### PR DESCRIPTION
Hi,

We have found and fixed 12 dependency issues in the Makefile.
Those issues can cause incorrect results when the project is incrementally built.
For example, any changes in a header file will not cause the object file to be rebuilt, which is incorrect.

We've tested it on my computer, the fixed version worked as expected.
Looking forward to your confirmation.

We fix them by using the Auto-Dependency Generation technique mentioned here: http://make.mad-scientist.net/papers/advanced-auto-dependency-generation/

Thanks
Vemake