### PR TITLE
ck_fifo: Return fifo->garbage at spsc deinit

### DIFF
--- a/include/ck_fifo.h
+++ b/include/ck_fifo.h
@@ -115,7 +115,7 @@ CK_CC_INLINE static void
 ck_fifo_spsc_deinit(struct ck_fifo_spsc *fifo, struct ck_fifo_spsc_entry **garbage)
 {
 
-	*garbage = fifo->head;
+	*garbage = fifo->garbage;
 	fifo->head = fifo->tail = NULL;
 	return;
 }


### PR DESCRIPTION
This code was returning the head of the fifo as garbage during a
de-init. It should instead return the fifo->garbage value.