### PR TITLE
Add support for setting AR

### DIFF
--- a/configure
+++ b/configure
@@ -146,6 +146,7 @@ generate_stdout()
 	echo "           SRC_DIR = $BUILD_DIR"
 	echo "            SYSTEM = $SYSTEM"
 	echo "           PROFILE = $PROFILE"
+	echo "                AR = $AR"
 	echo "                CC = $CC"
 	echo "          COMPILER = $COMPILER"
 	echo "            CFLAGS = $CFLAGS"
@@ -215,6 +216,7 @@ for option; do
 		echo "  --cores=N                Specify number of cores available on target machine"
 		echo
 		echo "The following environment variables may be used:"
+		echo "   AR       AR archiver command"
 		echo "   CC       C compiler command"
 		echo "   CFLAGS   C compiler flags"
 		echo "   LDFLAGS  Linker flags"
@@ -644,6 +646,15 @@ if test ! -x "${CC}"; then
 	fi
 fi
 assert "$CC" "not found"
+
+printf "Finding suitable archiver........"
+if test ! -x "${AR}"; then
+	AR=`pathsearch "${AR:-ar}"`
+	if test -z "$AR" -o ! -x "$AR"; then
+		AR=`pathsearch "${AR:-ar}"`
+	fi
+fi
+assert "$AR" "not found"
 
 cat << EOF > .1.c
 #include <stdio.h>

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -25,7 +25,7 @@ libck.so: $(OBJECTS)
 	$(LD) $(LDFLAGS) -o $(TARGET_DIR)/libck.so $(OBJECTS)
 
 libck.a: $(OBJECTS)
-	ar rcs $(TARGET_DIR)/libck.a $(OBJECTS)
+	$(AR) rcs $(TARGET_DIR)/libck.a $(OBJECTS)
 
 ck_array.o: $(INCLUDE_DIR)/ck_array.h $(SDIR)/ck_array.c
 	$(CC) $(CFLAGS) -c -o $(TARGET_DIR)/ck_array.o $(SDIR)/ck_array.c


### PR DESCRIPTION
By default, the command 'ar' is called. Is should be possible, as with
'CC', to override that value and set an own AR.

Signed-off-by: Conrad Kostecki <conrad@kostecki.com>