### PR TITLE
Rework ck_ec tests when invoking FUTEX_WAIT_BITSET

### DIFF
--- a/regressions/ck_ec/benchmark/ck_ec.c
+++ b/regressions/ck_ec/benchmark/ck_ec.c
@@ -121,7 +121,7 @@ static void wait32(const struct ck_ec_wait_state *state,
 	assert(state->ops == &test_ops);
 	syscall(SYS_futex, address,
 		FUTEX_WAIT_BITSET, expected, deadline,
-		NULL, deadline, 0);
+		NULL, FUTEX_BITSET_MATCH_ANY, 0);
 	return;
 }
 
@@ -143,7 +143,7 @@ static void wait64(const struct ck_ec_wait_state *state,
 
 	syscall(SYS_futex, low_half,
 		FUTEX_WAIT_BITSET, (uint32_t)expected, deadline,
-		NULL, deadline, 0);
+		NULL, FUTEX_BITSET_MATCH_ANY, 0);
 	return;
 }
 

--- a/regressions/ck_ec/validate/ck_ec_smoke_test.c
+++ b/regressions/ck_ec/validate/ck_ec_smoke_test.c
@@ -46,7 +46,7 @@ static void wait32(const struct ck_ec_wait_state *state,
 	assert(state->ops == &test_ops);
 	syscall(SYS_futex, address,
 		FUTEX_WAIT_BITSET, expected, deadline,
-		NULL, deadline, 0);
+		NULL, FUTEX_BITSET_MATCH_ANY, 0);
 	return;
 }
 
@@ -68,7 +68,7 @@ static void wait64(const struct ck_ec_wait_state *state,
 
 	syscall(SYS_futex, low_half,
 		FUTEX_WAIT_BITSET, (uint32_t)expected, deadline,
-		NULL, deadline, 0);
+		NULL, FUTEX_BITSET_MATCH_ANY, 0);
 	return;
 }
 


### PR DESCRIPTION
This PR reworks how futex is called in the `ck_ec` tests and benchmarks.

Presently, the wait half of the syscall is invoked like so:

```c
	syscall(SYS_futex, address,
		FUTEX_WAIT_BITSET, expected, deadline,
		NULL, /* `val3` argument */ deadline, 0);
```

This results in the syscall failing with `EINVAL` when `deadline` is `NULL`.

```bash
   FUTEX_WAIT_BITSET (since Linux 2.6.25)
              This operation is like FUTEX_WAIT except that val3 is used
              to provide a 32-bit bit mask to the kernel.  This bit
              mask, in which at least one bit must be set, is stored in
              the kernel-internal state of the waiter.  See the
              description of FUTEX_WAKE_BITSET for further details.
```

I think this may cause confusion if people use the benchmark/validation code as a starting point for their `wait`/`wake` callbacks.  The callbacks will work but `NULL` timeouts will result in a busy-wait.

[Small program demonstrating the behavior](https://gist.github.com/michael-grunder/b9caa3f5c1979c36ecadbaf50d7d9af6)