### PR TITLE
ck_pr: fix ptr output operand widths on x86 and x86_64

### DIFF
--- a/include/gcc/x86/ck_pr.h
+++ b/include/gcc/x86/ck_pr.h
@@ -120,7 +120,7 @@ CK_PR_FENCE(unlock, CK_MD_X86_MFENCE)
 		return v;					\
 	}
 
-CK_PR_FAS(ptr, void, void *, char, "xchgl")
+CK_PR_FAS(ptr, void, void *, uint32_t, "xchgl")
 
 #define CK_PR_FAS_S(S, T, I) CK_PR_FAS(S, T, T, T, I)
 
@@ -146,7 +146,7 @@ CK_PR_FAS_S(8,  uint8_t,  "xchgb")
 		return (r);						\
 	}
 
-CK_PR_LOAD(ptr, void, void *, char, "movl")
+CK_PR_LOAD(ptr, void, void *, uint32_t, "movl")
 
 #define CK_PR_LOAD_S(S, T, I) CK_PR_LOAD(S, T, T, T, I)
 
@@ -171,7 +171,7 @@ CK_PR_LOAD_S(8,  uint8_t,  "movb")
 		return;						\
 	}
 
-CK_PR_STORE(ptr, void, const void *, char, "movl")
+CK_PR_STORE(ptr, void, const void *, uint32_t, "movl")
 
 #define CK_PR_STORE_S(S, T, I) CK_PR_STORE(S, T, T, T, I)
 
@@ -200,7 +200,7 @@ CK_PR_STORE_S(8,  uint8_t, "movb")
 		return (d);						\
 	}
 
-CK_PR_FAA(ptr, void, uintptr_t, char, "xaddl")
+CK_PR_FAA(ptr, void, uintptr_t, uint32_t, "xaddl")
 
 #define CK_PR_FAA_S(S, T, I) CK_PR_FAA(S, T, T, T, I)
 
@@ -248,7 +248,7 @@ CK_PR_FAA_S(8,  uint8_t,  "xaddb")
 #define CK_PR_UNARY_S(K, S, T, I) CK_PR_UNARY(K, S, T, T, I)
 
 #define CK_PR_GENERATE(K)				\
-	CK_PR_UNARY(K, ptr, void, char, #K "l") 	\
+	CK_PR_UNARY(K, ptr, void, uint32_t, #K "l") 	\
 	CK_PR_UNARY_S(K, char, char, #K "b")		\
 	CK_PR_UNARY_S(K, int, int, #K "l")		\
 	CK_PR_UNARY_S(K, uint, unsigned int, #K "l")	\
@@ -288,7 +288,7 @@ CK_PR_GENERATE(not)
 #define CK_PR_BINARY_S(K, S, T, I) CK_PR_BINARY(K, S, T, T, T, I)
 
 #define CK_PR_GENERATE(K)					\
-	CK_PR_BINARY(K, ptr, void, uintptr_t, char, #K "l")	\
+	CK_PR_BINARY(K, ptr, void, uintptr_t, uint32_t, #K "l")	\
 	CK_PR_BINARY_S(K, char, char, #K "b")			\
 	CK_PR_BINARY_S(K, int, int, #K "l")			\
 	CK_PR_BINARY_S(K, uint, unsigned int, #K "l")		\
@@ -369,7 +369,7 @@ CK_PR_GENERATE(xor)
 	}
 #endif
 
-CK_PR_CAS(ptr, void, void *, char, "cmpxchgl")
+CK_PR_CAS(ptr, void, void *, uint32_t, "cmpxchgl")
 
 #define CK_PR_CAS_S(S, T, I) CK_PR_CAS(S, T, T, T, I)
 
@@ -401,11 +401,11 @@ CK_PR_CAS_S(8,  uint8_t,  "cmpxchgb")
 
 #define CK_PR_BT_S(K, S, T, I) CK_PR_BT(K, S, T, T, T, I)
 
-#define CK_PR_GENERATE(K)					\
-	CK_PR_BT(K, ptr, void, uint32_t, char, #K "l %2, %0")	\
-	CK_PR_BT_S(K, uint, unsigned int, #K "l %2, %0")	\
-	CK_PR_BT_S(K, int, int, #K "l %2, %0")			\
-	CK_PR_BT_S(K, 32, uint32_t, #K "l %2, %0")		\
+#define CK_PR_GENERATE(K)						\
+	CK_PR_BT(K, ptr, void, uint32_t, uint32_t, #K "l %2, %0")	\
+	CK_PR_BT_S(K, uint, unsigned int, #K "l %2, %0")		\
+	CK_PR_BT_S(K, int, int, #K "l %2, %0")				\
+	CK_PR_BT_S(K, 32, uint32_t, #K "l %2, %0")			\
 	CK_PR_BT_S(K, 16, uint16_t, #K "w %w2, %0")
 
 CK_PR_GENERATE(btc)

--- a/include/gcc/x86_64/ck_pr.h
+++ b/include/gcc/x86_64/ck_pr.h
@@ -149,7 +149,7 @@ ck_pr_rfo(const void *m)
 		return v;					\
 	}
 
-CK_PR_FAS(ptr, void, void *, char, "xchgq")
+CK_PR_FAS(ptr, void, void *, uint64_t, "xchgq")
 
 #define CK_PR_FAS_S(S, T, I) CK_PR_FAS(S, T, T, T, I)
 
@@ -182,7 +182,7 @@ CK_PR_FAS_S(8,  uint8_t,  "xchgb")
 		return (r);					\
 	}
 
-CK_PR_LOAD(ptr, void, void *, char, "movq")
+CK_PR_LOAD(ptr, void, void *, uint64_t, "movq")
 
 #define CK_PR_LOAD_S(S, T, I) CK_PR_LOAD(S, T, T, T, I)
 
@@ -264,7 +264,7 @@ CK_PR_LOAD_2(8, 16, uint8_t)
 		return;						\
 	}
 
-CK_PR_STORE_IMM(ptr, void, const void *, char, "movq", CK_CC_IMM_U32)
+CK_PR_STORE_IMM(ptr, void, const void *, uint64_t, "movq", CK_CC_IMM_U32)
 #ifndef CK_PR_DISABLE_DOUBLE
 CK_PR_STORE(double, double, double, double, "movq")
 #endif
@@ -298,7 +298,7 @@ CK_PR_STORE_S(8,  uint8_t, "movb", CK_CC_IMM_U32)
 		return (d);						\
 	}
 
-CK_PR_FAA(ptr, void, uintptr_t, char, "xaddq")
+CK_PR_FAA(ptr, void, uintptr_t, uint64_t, "xaddq")
 
 #define CK_PR_FAA_S(S, T, I) CK_PR_FAA(S, T, T, T, I)
 
@@ -347,7 +347,7 @@ CK_PR_FAA_S(8,  uint8_t,  "xaddb")
 #define CK_PR_UNARY_S(K, S, T, I) CK_PR_UNARY(K, S, T, T, I)
 
 #define CK_PR_GENERATE(K)				\
-	CK_PR_UNARY(K, ptr, void, char, #K "q") 	\
+	CK_PR_UNARY(K, ptr, void, uint64_t, #K "q") 	\
 	CK_PR_UNARY_S(K, char, char, #K "b")		\
 	CK_PR_UNARY_S(K, int, int, #K "l")		\
 	CK_PR_UNARY_S(K, uint, unsigned int, #K "l")	\
@@ -388,7 +388,7 @@ CK_PR_GENERATE(not)
 #define CK_PR_BINARY_S(K, S, T, I, O) CK_PR_BINARY(K, S, T, T, T, I, O)
 
 #define CK_PR_GENERATE(K)							\
-	CK_PR_BINARY(K, ptr, void, uintptr_t, char, #K "q", CK_CC_IMM_U32)	\
+	CK_PR_BINARY(K, ptr, void, uintptr_t, uint64_t, #K "q", CK_CC_IMM_U32)	\
 	CK_PR_BINARY_S(K, char, char, #K "b", CK_CC_IMM_S32)			\
 	CK_PR_BINARY_S(K, int, int, #K "l", CK_CC_IMM_S32)			\
 	CK_PR_BINARY_S(K, uint, unsigned int, #K "l", CK_CC_IMM_U32)		\
@@ -470,7 +470,7 @@ CK_PR_GENERATE(xor)
 	}
 #endif
 
-CK_PR_CAS(ptr, void, void *, char, "cmpxchgq")
+CK_PR_CAS(ptr, void, void *, uint64_t, "cmpxchgq")
 
 #define CK_PR_CAS_S(S, T, I) CK_PR_CAS(S, T, T, T, I)
 
@@ -594,12 +594,12 @@ CK_PR_CAS_V(8, 16, uint8_t)
 
 #define CK_PR_BT_S(K, S, T, I) CK_PR_BT(K, S, T, T, T, I)
 
-#define CK_PR_GENERATE(K)					\
-	CK_PR_BT(K, ptr, void, uint64_t, char, #K "q %2, %0")	\
-	CK_PR_BT_S(K, uint, unsigned int, #K "l %2, %0")	\
-	CK_PR_BT_S(K, int, int, #K "l %2, %0")			\
-	CK_PR_BT_S(K, 64, uint64_t, #K "q %2, %0")		\
-	CK_PR_BT_S(K, 32, uint32_t, #K "l %2, %0")		\
+#define CK_PR_GENERATE(K)						\
+	CK_PR_BT(K, ptr, void, uint64_t, uint64_t, #K "q %2, %0")	\
+	CK_PR_BT_S(K, uint, unsigned int, #K "l %2, %0")		\
+	CK_PR_BT_S(K, int, int, #K "l %2, %0")				\
+	CK_PR_BT_S(K, 64, uint64_t, #K "q %2, %0")			\
+	CK_PR_BT_S(K, 32, uint32_t, #K "l %2, %0")			\
 	CK_PR_BT_S(K, 16, uint16_t, #K "w %w2, %0")
 
 CK_PR_GENERATE(btc)


### PR DESCRIPTION
Operations on a variable of type "ptr" specify that the output operand
can be a memory address.  Most such operations specify that the output
operand is of type char, so it has width 1.  Convert these to uint64_t
on x86_64 and uint32_t on x86.

No functional change intended.  With clang 12.0.1 there is no difference
in the generated code before and after this change.

The compiler needs to know the true width of the destination operand in
some cases.  In particular, when compiling with LLVM's MemorySanitizer
enabled, the generated code updates shadow state to mark variables as
initialized (or not) at byte granularity.  When instrumenting inline
assembly, the compiler uses the width of the output operand(s) to figure
out how many bytes of shadow state to update.  When the output operand
is cast to char, the runtime would only update one byte of shadow state
even though the store modified eight bytes of memory.  This led to false
positives when enabling MSAN in the FreeBSD kernel.