### PR TITLE
build: Use ilp32d abi on riscv32

### DIFF
--- a/build/ck.build.riscv
+++ b/build/ck.build.riscv
@@ -1,1 +1,1 @@
-CFLAGS+=-mabi=ilp32
+CFLAGS+=-mabi=ilp32d

--- a/build/ck.build.riscv64
+++ b/build/ck.build.riscv64
@@ -1,1 +1,1 @@
-CFLAGS+=-mabi=lp64
+CFLAGS+=-mabi=lp64d


### PR DESCRIPTION
ilp32d is common ABI used for linux distributions therefore a better default

Signed-off-by: Khem Raj <raj.khem@gmail.com>