### PR TITLE
Preserve timestamps of installed files

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -34,15 +34,15 @@ check: regressions
 
 install-headers:
 	mkdir -p $(DESTDIR)/$(HEADERS) || exit
-	cp $(SRC_DIR)/include/*.h $(DESTDIR)/$(HEADERS) || exit
+	cp -p $(SRC_DIR)/include/*.h $(DESTDIR)/$(HEADERS) || exit
 	chmod 644 $(DESTDIR)/$(HEADERS)/ck_*.h || exit
 	mkdir -p $(DESTDIR)/$(HEADERS)/gcc || exit
 	cp -r $(SRC_DIR)/include/gcc/* $(DESTDIR)/$(HEADERS)/gcc || exit
-	cp include/ck_md.h $(DESTDIR)/$(HEADERS)/ck_md.h || exit
+	cp -p include/ck_md.h $(DESTDIR)/$(HEADERS)/ck_md.h || exit
 	chmod 755 $(DESTDIR)/$(HEADERS)/gcc
 	chmod 644 $(DESTDIR)/$(HEADERS)/gcc/ck_*.h $(DESTDIR)/$(HEADERS)/gcc/*/ck_*.h || exit
 	mkdir -p $(DESTDIR)/$(HEADERS)/spinlock || exit
-	cp -r $(SRC_DIR)/include/spinlock/* $(DESTDIR)/$(HEADERS)/spinlock || exit
+	cp -pr $(SRC_DIR)/include/spinlock/* $(DESTDIR)/$(HEADERS)/spinlock || exit
 	chmod 755 $(DESTDIR)/$(HEADERS)/spinlock
 	chmod 644 $(DESTDIR)/$(HEADERS)/spinlock/*.h || exit
 
@@ -51,7 +51,7 @@ install-so:
 	cp src/libck.so $(DESTDIR)/$(LIBRARY)/$(LDNAME_VERSION)
 	ln -sf $(LDNAME_VERSION) $(DESTDIR)/$(LIBRARY)/$(LDNAME)
 	ln -sf $(LDNAME_VERSION) $(DESTDIR)/$(LIBRARY)/$(LDNAME_MAJOR)
-	chmod 744 $(DESTDIR)/$(LIBRARY)/$(LDNAME_VERSION)	\
+	chmod 755 $(DESTDIR)/$(LIBRARY)/$(LDNAME_VERSION)	\
 		  $(DESTDIR)/$(LIBRARY)/$(LDNAME)		\
 		  $(DESTDIR)/$(LIBRARY)/$(LDNAME_MAJOR)
 
@@ -65,7 +65,7 @@ install: all install-headers @INSTALL_LIBS@
 	mkdir -p $(DESTDIR)/$(LIBRARY) || exit
 	mkdir -p $(DESTDIR)/$(PKGCONFIG_DATA) || exit
 	chmod 755 $(DESTDIR)/$(PKGCONFIG_DATA)
-	cp build/ck.pc $(DESTDIR)/$(PKGCONFIG_DATA)/ck.pc || exit
+	cp -p build/ck.pc $(DESTDIR)/$(PKGCONFIG_DATA)/ck.pc || exit
 	@echo
 	@echo
 	@echo ---[ Concurrency Kit has installed successfully.

--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -206,7 +206,7 @@ refcheck:
 
 install:
 	mkdir -p $(DESTDIR)/$(MANDIR)/man3 || exit
-	cp *$(GZIP_SUFFIX) $(DESTDIR)/$(MANDIR)/man3 || exit
+	cp -p *$(GZIP_SUFFIX) $(DESTDIR)/$(MANDIR)/man3 || exit
 
 uninstall:
 	for target in $(OBJECTS); do 			  \


### PR DESCRIPTION
Preserve original timestamps when doing cp of non-built files. That allows keeping headers unmodified on package upgrades when those headers were not modified. Gzip keeps timestamps too, so do that also for manual pages.

Correct mode of shared library to be executable by everyone. Desired especially when installing by root user.