### PR TITLE
ck_pr/arm: Add support for armv7ve

### DIFF
--- a/include/gcc/arm/ck_f_pr.h
+++ b/include/gcc/arm/ck_f_pr.h
@@ -20,7 +20,7 @@
 #define CK_F_PR_CAS_16_VALUE
 #define CK_F_PR_CAS_32
 #define CK_F_PR_CAS_32_VALUE
-#if defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__)
+#if defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_7VE__)
 #define CK_F_PR_CAS_64
 #define CK_F_PR_CAS_64_VALUE
 #define CK_F_PR_CAS_DOUBLE
@@ -33,7 +33,7 @@
 #define CK_F_PR_CAS_INT
 #define CK_F_PR_CAS_INT_VALUE
 #define CK_F_PR_CAS_PTR
-#if defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__)
+#if defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_7VE__)
 #define CK_F_PR_CAS_PTR_2
 #define CK_F_PR_CAS_PTR_2_VALUE
 #endif
@@ -97,7 +97,7 @@
 #define CK_F_PR_INC_UINT
 #define CK_F_PR_LOAD_16
 #define CK_F_PR_LOAD_32
-#if defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__)
+#if defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_7VE__)
 #define CK_F_PR_LOAD_64
 #define CK_F_PR_LOAD_DOUBLE
 #endif
@@ -134,7 +134,7 @@
 #define CK_F_PR_STALL
 #define CK_F_PR_STORE_16
 #define CK_F_PR_STORE_32
-#if defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__)
+#if defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_7VE__)
 #define CK_F_PR_STORE_64
 #define CK_F_PR_STORE_DOUBLE
 #endif

--- a/include/gcc/arm/ck_pr.h
+++ b/include/gcc/arm/ck_pr.h
@@ -54,7 +54,7 @@ ck_pr_stall(void)
 	return;
 }
 
-#if defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__)
+#if defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_7VE__)
 #define CK_ISB __asm __volatile("isb" : : "r" (0) : "memory")
 #define CK_DMB __asm __volatile("dmb" : : "r" (0) : "memory")
 #define CK_DSB __asm __volatile("dsb" : : "r" (0) : "memory")
@@ -132,7 +132,7 @@ CK_PR_LOAD_S(char, char, "ldrb")
 #undef CK_PR_LOAD_S
 #undef CK_PR_LOAD
 
-#if defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__)
+#if defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_7VE__)
 
 #define CK_PR_DOUBLE_LOAD(T, N) 		\
 CK_CC_INLINE static T				\
@@ -181,7 +181,7 @@ CK_PR_STORE_S(char, char, "strb")
 #undef CK_PR_STORE_S
 #undef CK_PR_STORE
 
-#if defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__)
+#if defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_7VE__)
 
 #define CK_PR_DOUBLE_STORE(T, N)				\
 CK_CC_INLINE static void					\


### PR DESCRIPTION
This is simply another variant of armv7, but the #defines differ.  Update to allow this additional variant.