### PR TITLE
ck_pr/aarch64: Specify output operands for ck_pr_md_store_*

### DIFF
--- a/include/gcc/aarch64/ck_pr.h
+++ b/include/gcc/aarch64/ck_pr.h
@@ -138,7 +138,7 @@ CK_PR_LOAD_S_64(double, double, "ldr")
 	ck_pr_md_store_##S(M *target, T v)			\
 	{							\
 		__asm__ __volatile__(I " %w1, [%0]"		\
-					:			\
+					: "=m" (*(T **)target)	\
 					: "r" (target),		\
 					  "r" (v)		\
 					: "memory");		\
@@ -149,7 +149,7 @@ CK_PR_LOAD_S_64(double, double, "ldr")
 	ck_pr_md_store_##S(M *target, T v)			\
 	{							\
 		__asm__ __volatile__(I " %1, [%0]"		\
-					:			\
+					: "=m" (*(T **)target)	\
 					: "r" (target),		\
 					  "r" (v)		\
 					: "memory");		\


### PR DESCRIPTION
This is required to enable KMSAN for aarch64 on FreeBSD. It will likely also be useful for userspace code which makes use of CK and is compiled with MSAN enabled.