### PR TITLE
ck_pr/aarch64: Specify output operands for ck_pr_md_store_*

### DIFF
--- a/include/gcc/aarch64/ck_pr.h
+++ b/include/gcc/aarch64/ck_pr.h
@@ -137,8 +137,8 @@ CK_PR_LOAD_S_64(double, double, "ldr")
 	CK_CC_INLINE static void				\
 	ck_pr_md_store_##S(M *target, T v)			\
 	{							\
-		__asm__ __volatile__(I " %w1, [%0]"		\
-					:			\
+		__asm__ __volatile__(I " %w2, [%1]"		\
+					: "=m" (*(T *)target)	\
 					: "r" (target),		\
 					  "r" (v)		\
 					: "memory");		\
@@ -148,8 +148,8 @@ CK_PR_LOAD_S_64(double, double, "ldr")
 	CK_CC_INLINE static void				\
 	ck_pr_md_store_##S(M *target, T v)			\
 	{							\
-		__asm__ __volatile__(I " %1, [%0]"		\
-					:			\
+		__asm__ __volatile__(I " %2, [%1]"		\
+					: "=m" (*(T *)target)	\
 					: "r" (target),		\
 					  "r" (v)		\
 					: "memory");		\


### PR DESCRIPTION
As in commit 2f9acab, we want to specify output operand widths so that MSAN compiler instrumentation correctly updates the shadow map.  In particular, LLVM's implementation depends on having type information for output operands, even when that's not otherwise necessary.  Without it, KMSAN in FreeBSD generates false positives on aarch64.

Tested by running the regression suite on a MS DevKit running FreeBSD.