### PR TITLE
Correct array parameter notation in CK_PR_LOAD_2()

### DIFF
--- a/include/gcc/x86_64/ck_pr.h
+++ b/include/gcc/x86_64/ck_pr.h
@@ -223,7 +223,7 @@ ck_pr_load_ptr_2(const void *t, void *v)
 
 #define CK_PR_LOAD_2(S, W, T)							\
 	CK_CC_INLINE static void						\
-	ck_pr_md_load_##S##_##W(const T t[2], T v[2])				\
+	ck_pr_md_load_##S##_##W(const T t[W*sizeof(T)], T v[W*sizeof(T)]) 	\
 	{									\
 		ck_pr_load_64_2((const uint64_t *)(const void *)t,		\
 				(uint64_t *)(void *)v);				\

--- a/include/gcc/x86_64/ck_pr.h
+++ b/include/gcc/x86_64/ck_pr.h
@@ -223,7 +223,7 @@ ck_pr_load_ptr_2(const void *t, void *v)
 
 #define CK_PR_LOAD_2(S, W, T)							\
 	CK_CC_INLINE static void						\
-	ck_pr_md_load_##S##_##W(const T t[W*sizeof(T)], T v[W*sizeof(T)]) 	\
+	ck_pr_md_load_##S##_##W(const T t[W], T v[W]) 				\
 	{									\
 		ck_pr_load_64_2((const uint64_t *)(const void *)t,		\
 				(uint64_t *)(void *)v);				\


### PR DESCRIPTION
This type of array size notation in C serves only a documentation purpose.  That the array-size documentation provided in this macro-templated inline function declaration is not correct for any of the instantiations would be a minor nit except that gcc versions that support -Wstringop-overread and/or -Wstringop-overflow use the array sizes as guidance for when to generate those warnings (errors under -Werror).

An alternative would be to change the parameter types to explicitly be pointers - this fix preserves the documentation intent.

This resolves #185.