### PR TITLE
configure: fix handling of name=value argument processing

### DIFF
--- a/configure
+++ b/configure
@@ -175,14 +175,14 @@ generate_stdout()
 
 for option; do
 	case "$option" in
-	*=?*)
+	--*=?*)
 		optname=`echo $option|cut -c 3-`
 		value=`expr "$optname" : '[^=]*=\(.*\)'`
 		;;
-	*=)
+	--*=)
 		value=
 		;;
-	*)
+	--*)
 		value=yes
 		;;
 	esac
@@ -317,8 +317,8 @@ for option; do
 		fi
 		;;
 	*=*)
-		optname=`echo $option|cut -c 3-`
-		NAME=`expr "$optname" : '\([^=]*\)='`
+		value=`echo $option|cut -d '=' -f 2-`
+		NAME=`expr "$option" : '\([^=]*\)='`
 		eval "$NAME='$value'"
 		export $NAME
 		;;


### PR DESCRIPTION
The intent seemed to be there, but the implementation was broken. This fix restricts the common value extraction code to operating on options (i.e., args beginning with '--'), and repairs the '*=*' case so it properly extracts the name and value.  Now CFLAGS and other variables can be successfully passed on the command line.