### PR TITLE
configure: generate headers in the build directory, not the source directory

### DIFF
--- a/configure
+++ b/configure
@@ -867,22 +867,22 @@ PROFILE="${PROFILE:-$PLATFORM}"
 PLATFORM="__${PLATFORM}__"
 
 printf "Generating header files.........."
-generate include/ck_md.h.in include/ck_md.h
-generate include/freebsd/ck_md.h.in include/freebsd/ck_md.h
+mkdir -p $P_PWD/include
+mkdir -p $P_PWD/include/freebsd
+generate include/ck_md.h.in $P_PWD/include/ck_md.h
+generate include/freebsd/ck_md.h.in $P_PWD/include/freebsd/ck_md.h
 echo "success"
 
 printf "Generating build files..........."
 
 mkdir -p $P_PWD/doc
 mkdir -p $P_PWD/build
-mkdir -p $P_PWD/include
 mkdir -p $P_PWD/src
 
 if test "$P_PWD" '!=' "$BUILD_DIR"; then
 	mkdir -p $P_PWD/regressions
 	cp $BUILD_DIR/regressions/Makefile.unsupported $P_PWD/regressions/Makefile &> /dev/null
 	cp $BUILD_DIR/build/ck.build.$PROFILE $P_PWD/build/ck.build.$PROFILE &> /dev/null
-	cp $BUILD_DIR/include/ck_md.h $P_PWD/include/ck_md.h &> /dev/null
 fi
 
 generate src/Makefile.in $P_PWD/src/Makefile


### PR DESCRIPTION
The existing behavior was to generate two headers in the source directory and copy one of them to the build directory.  Now, both headers are generated in the build directory.  This allows a single source tree to properly support multiple, independently configured out of tree builds.

Note that the terminology in this configure script is currently such that "BUILD_DIR" is actually the source dir (root of the source tree), and "P_PWD" is the build dir (root of the build products tree).