### PR TITLE
initialize delta with NULL

### DIFF
--- a/src/ck_rhs.c
+++ b/src/ck_rhs.c
@@ -1145,7 +1145,7 @@ ck_rhs_apply(struct ck_rhs *hs,
     void *cl)
 {
 	const void *insert;
-	const void  *object, *delta = false;
+	const void  *object, *delta = NULL;
 	unsigned long n_probes;
 	long slot, first;
 	struct ck_rhs_map *map;


### PR DESCRIPTION
Initializing a pointer with `false` triggers undefined behaviour, and this is not valid since C23. When pointer needs to be initialized to 0, `NULL` is preferred over `false`.