### PR TITLE
Fix missing dependences in src/Makefile.in

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -6,6 +6,19 @@ TARGET_DIR=$(BUILD_DIR)/src
 SDIR=$(SRC_DIR)/src
 INCLUDE_DIR=$(SRC_DIR)/include
 
+Deps_ck_array = $(INCLUDE_DIR)/ck_stdint.h $(INCLUDE_DIR)/ck_cc.h $(INCLUDE_DIR)/ck_string.h $(INCLUDE_DIR)/ck_malloc.h $(INCLUDE_DIR)/ck_pr.h $(INCLUDE_DIR)/ck_stdbool.h $(INCLUDE_DIR)/ck_md.h $(INCLUDE_DIR)/ck_limits.h $(INCLUDE_DIR)/ck_stddef.h $(INCLUDE_DIR)/gcc/ck_cc.h $(INCLUDE_DIR)/gcc/ck_pr.h $(INCLUDE_DIR)/gcc/x86_64/ck_pr.h $(INCLUDE_DIR)/gcc/x86_64/ck_f_pr.h
+Deps_ck_hp = $(INCLUDE_DIR)/ck_stdint.h $(INCLUDE_DIR)/ck_cc.h $(INCLUDE_DIR)/ck_string.h $(INCLUDE_DIR)/ck_pr.h $(INCLUDE_DIR)/ck_backoff.h $(INCLUDE_DIR)/ck_stdlib.h $(INCLUDE_DIR)/ck_stdbool.h $(INCLUDE_DIR)/ck_md.h $(INCLUDE_DIR)/ck_limits.h $(INCLUDE_DIR)/ck_stddef.h $(INCLUDE_DIR)/gcc/ck_cc.h $(INCLUDE_DIR)/gcc/ck_pr.h $(INCLUDE_DIR)/gcc/x86_64/ck_pr.h $(INCLUDE_DIR)/gcc/x86_64/ck_f_pr.h
+Deps_ck_rhs = $(INCLUDE_DIR)/ck_stdint.h $(INCLUDE_DIR)/ck_cc.h $(INCLUDE_DIR)/ck_string.h $(INCLUDE_DIR)/ck_malloc.h $(INCLUDE_DIR)/ck_pr.h $(INCLUDE_DIR)/ck_stdbool.h $(INCLUDE_DIR)/ck_md.h $(INCLUDE_DIR)/ck_limits.h $(INCLUDE_DIR)/ck_stddef.h $(INCLUDE_DIR)/gcc/ck_cc.h $(INCLUDE_DIR)/gcc/ck_pr.h $(SDIR)/ck_internal.h $(INCLUDE_DIR)/gcc/x86_64/ck_pr.h $(INCLUDE_DIR)/gcc/x86_64/ck_f_pr.h
+Deps_ck_barrier_dissemination = $(INCLUDE_DIR)/ck_stdint.h $(INCLUDE_DIR)/ck_cc.h $(INCLUDE_DIR)/ck_string.h $(INCLUDE_DIR)/ck_spinlock.h $(INCLUDE_DIR)/ck_elide.h $(INCLUDE_DIR)/ck_pr.h $(INCLUDE_DIR)/ck_backoff.h $(INCLUDE_DIR)/ck_stdbool.h $(INCLUDE_DIR)/ck_md.h $(INCLUDE_DIR)/ck_limits.h $(INCLUDE_DIR)/ck_stddef.h $(INCLUDE_DIR)/ck_barrier.h $(INCLUDE_DIR)/spinlock/mcs.h $(INCLUDE_DIR)/spinlock/clh.h $(INCLUDE_DIR)/spinlock/hclh.h $(INCLUDE_DIR)/spinlock/fas.h $(INCLUDE_DIR)/spinlock/dec.h $(INCLUDE_DIR)/spinlock/anderson.h $(INCLUDE_DIR)/spinlock/cas.h $(INCLUDE_DIR)/spinlock/ticket.h $(INCLUDE_DIR)/gcc/ck_cc.h $(INCLUDE_DIR)/gcc/ck_pr.h $(SDIR)/ck_internal.h $(INCLUDE_DIR)/gcc/x86_64/ck_pr.h $(INCLUDE_DIR)/gcc/x86_64/ck_f_pr.h
+Deps_ck_ec = $(INCLUDE_DIR)/ck_stdint.h $(INCLUDE_DIR)/ck_limits.h $(INCLUDE_DIR)/ck_stdbool.h $(INCLUDE_DIR)/ck_cc.h $(INCLUDE_DIR)/ck_stddef.h $(INCLUDE_DIR)/ck_pr.h $(INCLUDE_DIR)/ck_md.h $(INCLUDE_DIR)/gcc/x86_64/ck_f_pr.h $(INCLUDE_DIR)/gcc/x86_64/ck_pr.h $(INCLUDE_DIR)/gcc/ck_cc.h $(INCLUDE_DIR)/gcc/ck_pr.h
+Deps_ck_barrier_tournament = $(INCLUDE_DIR)/ck_stdint.h $(INCLUDE_DIR)/ck_cc.h $(INCLUDE_DIR)/ck_string.h $(INCLUDE_DIR)/ck_spinlock.h $(INCLUDE_DIR)/ck_elide.h $(INCLUDE_DIR)/ck_pr.h $(INCLUDE_DIR)/ck_backoff.h $(INCLUDE_DIR)/ck_stdbool.h $(INCLUDE_DIR)/ck_md.h $(INCLUDE_DIR)/ck_limits.h $(INCLUDE_DIR)/ck_stddef.h $(INCLUDE_DIR)/ck_barrier.h $(INCLUDE_DIR)/spinlock/mcs.h $(INCLUDE_DIR)/spinlock/clh.h $(INCLUDE_DIR)/spinlock/hclh.h $(INCLUDE_DIR)/spinlock/fas.h $(INCLUDE_DIR)/spinlock/dec.h $(INCLUDE_DIR)/spinlock/anderson.h $(INCLUDE_DIR)/spinlock/cas.h $(INCLUDE_DIR)/spinlock/ticket.h $(INCLUDE_DIR)/gcc/ck_cc.h $(INCLUDE_DIR)/gcc/ck_pr.h $(SDIR)/ck_internal.h $(INCLUDE_DIR)/gcc/x86_64/ck_pr.h $(INCLUDE_DIR)/gcc/x86_64/ck_f_pr.h
+Deps_ck_ht = $(INCLUDE_DIR)/ck_stdint.h $(INCLUDE_DIR)/ck_cc.h $(INCLUDE_DIR)/ck_string.h $(INCLUDE_DIR)/ck_malloc.h $(INCLUDE_DIR)/ck_pr.h $(INCLUDE_DIR)/ck_stdbool.h $(INCLUDE_DIR)/ck_md.h $(INCLUDE_DIR)/ck_limits.h $(INCLUDE_DIR)/ck_stddef.h $(INCLUDE_DIR)/gcc/ck_cc.h $(INCLUDE_DIR)/gcc/ck_pr.h $(SDIR)/ck_internal.h $(SDIR)/ck_ht_hash.h $(INCLUDE_DIR)/gcc/x86_64/ck_pr.h $(INCLUDE_DIR)/gcc/x86_64/ck_f_pr.h
+Deps_ck_barrier_combining = $(INCLUDE_DIR)/ck_stdint.h $(INCLUDE_DIR)/ck_string.h $(INCLUDE_DIR)/ck_limits.h $(INCLUDE_DIR)/ck_spinlock.h $(INCLUDE_DIR)/ck_stdbool.h $(INCLUDE_DIR)/ck_cc.h $(INCLUDE_DIR)/ck_stddef.h $(INCLUDE_DIR)/ck_elide.h $(INCLUDE_DIR)/ck_barrier.h $(INCLUDE_DIR)/ck_pr.h $(INCLUDE_DIR)/ck_md.h $(INCLUDE_DIR)/ck_backoff.h $(INCLUDE_DIR)/spinlock/mcs.h $(INCLUDE_DIR)/spinlock/dec.h $(INCLUDE_DIR)/spinlock/fas.h $(INCLUDE_DIR)/spinlock/cas.h $(INCLUDE_DIR)/spinlock/ticket.h $(INCLUDE_DIR)/spinlock/clh.h $(INCLUDE_DIR)/spinlock/anderson.h $(INCLUDE_DIR)/spinlock/hclh.h $(INCLUDE_DIR)/gcc/x86_64/ck_f_pr.h $(INCLUDE_DIR)/gcc/x86_64/ck_pr.h $(INCLUDE_DIR)/gcc/ck_cc.h $(INCLUDE_DIR)/gcc/ck_pr.h
+Deps_ck_barrier_mcs = $(INCLUDE_DIR)/ck_stdint.h $(INCLUDE_DIR)/ck_string.h $(INCLUDE_DIR)/ck_limits.h $(INCLUDE_DIR)/ck_spinlock.h $(INCLUDE_DIR)/ck_cc.h $(INCLUDE_DIR)/ck_stdbool.h $(INCLUDE_DIR)/ck_stddef.h $(INCLUDE_DIR)/ck_elide.h $(INCLUDE_DIR)/ck_barrier.h $(INCLUDE_DIR)/ck_pr.h $(INCLUDE_DIR)/ck_md.h $(INCLUDE_DIR)/ck_backoff.h $(INCLUDE_DIR)/spinlock/mcs.h $(INCLUDE_DIR)/spinlock/cas.h $(INCLUDE_DIR)/spinlock/dec.h $(INCLUDE_DIR)/spinlock/fas.h $(INCLUDE_DIR)/spinlock/ticket.h $(INCLUDE_DIR)/spinlock/clh.h $(INCLUDE_DIR)/spinlock/anderson.h $(INCLUDE_DIR)/spinlock/hclh.h $(INCLUDE_DIR)/gcc/x86_64/ck_f_pr.h $(INCLUDE_DIR)/gcc/x86_64/ck_pr.h $(INCLUDE_DIR)/gcc/ck_cc.h $(INCLUDE_DIR)/gcc/ck_pr.h
+Deps_ck_hs = $(INCLUDE_DIR)/ck_stdint.h $(INCLUDE_DIR)/ck_cc.h $(INCLUDE_DIR)/ck_string.h $(INCLUDE_DIR)/ck_malloc.h $(INCLUDE_DIR)/ck_pr.h $(INCLUDE_DIR)/ck_stdbool.h $(INCLUDE_DIR)/ck_md.h $(INCLUDE_DIR)/ck_limits.h $(INCLUDE_DIR)/ck_stddef.h $(INCLUDE_DIR)/gcc/ck_cc.h $(INCLUDE_DIR)/gcc/ck_pr.h $(SDIR)/ck_internal.h $(INCLUDE_DIR)/gcc/x86_64/ck_pr.h $(INCLUDE_DIR)/gcc/x86_64/ck_f_pr.h
+Deps_ck_barrier_centralized = $(INCLUDE_DIR)/ck_stdint.h $(INCLUDE_DIR)/ck_string.h $(INCLUDE_DIR)/ck_limits.h $(INCLUDE_DIR)/ck_spinlock.h $(INCLUDE_DIR)/ck_stdbool.h $(INCLUDE_DIR)/ck_cc.h $(INCLUDE_DIR)/ck_stddef.h $(INCLUDE_DIR)/ck_elide.h $(INCLUDE_DIR)/ck_barrier.h $(INCLUDE_DIR)/ck_pr.h $(INCLUDE_DIR)/ck_md.h $(INCLUDE_DIR)/ck_backoff.h $(INCLUDE_DIR)/spinlock/mcs.h $(INCLUDE_DIR)/spinlock/dec.h $(INCLUDE_DIR)/spinlock/fas.h $(INCLUDE_DIR)/spinlock/cas.h $(INCLUDE_DIR)/spinlock/ticket.h $(INCLUDE_DIR)/spinlock/clh.h $(INCLUDE_DIR)/spinlock/anderson.h $(INCLUDE_DIR)/spinlock/hclh.h $(INCLUDE_DIR)/gcc/x86_64/ck_f_pr.h $(INCLUDE_DIR)/gcc/x86_64/ck_pr.h $(INCLUDE_DIR)/gcc/ck_cc.h $(INCLUDE_DIR)/gcc/ck_pr.h
+Deps_ck_epoch = $(INCLUDE_DIR)/ck_stdint.h $(INCLUDE_DIR)/ck_string.h $(INCLUDE_DIR)/ck_limits.h $(INCLUDE_DIR)/ck_stdbool.h $(INCLUDE_DIR)/ck_cc.h $(INCLUDE_DIR)/ck_stddef.h $(INCLUDE_DIR)/ck_pr.h $(INCLUDE_DIR)/ck_md.h $(INCLUDE_DIR)/ck_backoff.h $(INCLUDE_DIR)/gcc/x86_64/ck_f_pr.h $(INCLUDE_DIR)/gcc/x86_64/ck_pr.h $(INCLUDE_DIR)/gcc/ck_cc.h $(INCLUDE_DIR)/gcc/ck_pr.h
+
 OBJECTS=ck_barrier_centralized.o	\
 	ck_barrier_combining.o		\
 	ck_barrier_dissemination.o	\
@@ -27,41 +40,42 @@ libck.so: $(OBJECTS)
 libck.a: $(OBJECTS)
 	$(AR) rcs $(TARGET_DIR)/libck.a $(OBJECTS)
 
-ck_array.o: $(INCLUDE_DIR)/ck_array.h $(SDIR)/ck_array.c
+ck_array.o: $(Deps_ck_array) $(INCLUDE_DIR)/ck_array.h $(SDIR)/ck_array.c
 	$(CC) $(CFLAGS) -c -o $(TARGET_DIR)/ck_array.o $(SDIR)/ck_array.c
 
-ck_ec.o: $(INCLUDE_DIR)/ck_ec.h $(SDIR)/ck_ec.c $(SDIR)/ck_ec_timeutil.h
+ck_ec.o: $(Deps_ck_ec) $(INCLUDE_DIR)/ck_ec.h $(SDIR)/ck_ec.c $(SDIR)/ck_ec_timeutil.h
 	$(CC) $(CFLAGS) -c -o $(TARGET_DIR)/ck_ec.o $(SDIR)/ck_ec.c
 
-ck_epoch.o: $(INCLUDE_DIR)/ck_epoch.h $(SDIR)/ck_epoch.c $(INCLUDE_DIR)/ck_stack.h
+ck_epoch.o: $(Deps_ck_epoch) $(INCLUDE_DIR)/ck_epoch.h $(SDIR)/ck_epoch.c $(INCLUDE_DIR)/ck_stack.h
 	$(CC) $(CFLAGS) -c -o $(TARGET_DIR)/ck_epoch.o $(SDIR)/ck_epoch.c
 
-ck_hs.o: $(INCLUDE_DIR)/ck_hs.h $(SDIR)/ck_hs.c
+ck_hs.o: $(Deps_ck_hs) $(INCLUDE_DIR)/ck_hs.h $(SDIR)/ck_hs.c
 	$(CC) $(CFLAGS) -c -o $(TARGET_DIR)/ck_hs.o $(SDIR)/ck_hs.c
 
-ck_rhs.o: $(INCLUDE_DIR)/ck_rhs.h $(SDIR)/ck_rhs.c
+ck_rhs.o: $(Deps_ck_rhs) $(INCLUDE_DIR)/ck_rhs.h $(SDIR)/ck_rhs.c
 	$(CC) $(CFLAGS) -c -o $(TARGET_DIR)/ck_rhs.o $(SDIR)/ck_rhs.c
 
-ck_ht.o: $(INCLUDE_DIR)/ck_ht.h $(SDIR)/ck_ht.c
+ck_ht.o: $(Deps_ck_ht) $(INCLUDE_DIR)/ck_ht.h $(SDIR)/ck_ht.c
 	$(CC) $(CFLAGS) -c -o $(TARGET_DIR)/ck_ht.o $(SDIR)/ck_ht.c
 
-ck_hp.o: $(SDIR)/ck_hp.c $(INCLUDE_DIR)/ck_hp.h $(INCLUDE_DIR)/ck_stack.h
+ck_hp.o: $(Deps_ck_hp) $(SDIR)/ck_hp.c $(INCLUDE_DIR)/ck_hp.h $(INCLUDE_DIR)/ck_stack.h
 	$(CC) $(CFLAGS) -c -o $(TARGET_DIR)/ck_hp.o $(SDIR)/ck_hp.c
 
-ck_barrier_centralized.o: $(SDIR)/ck_barrier_centralized.c
+ck_barrier_centralized.o: $(Deps_ck_barrier_centralized) $(SDIR)/ck_barrier_centralized.c
 	$(CC) $(CFLAGS) -c -o $(TARGET_DIR)/ck_barrier_centralized.o $(SDIR)/ck_barrier_centralized.c
 
-ck_barrier_combining.o: $(SDIR)/ck_barrier_combining.c
+ck_barrier_combining.o: $(Deps_ck_barrier_combining) $(SDIR)/ck_barrier_combining.c
 	$(CC) $(CFLAGS) -c -o $(TARGET_DIR)/ck_barrier_combining.o $(SDIR)/ck_barrier_combining.c
 
-ck_barrier_dissemination.o: $(SDIR)/ck_barrier_dissemination.c
+ck_barrier_dissemination.o: $(Deps_ck_barrier_dissemination) $(SDIR)/ck_barrier_dissemination.c
 	$(CC) $(CFLAGS) -c -o $(TARGET_DIR)/ck_barrier_dissemination.o $(SDIR)/ck_barrier_dissemination.c
 
-ck_barrier_tournament.o: $(SDIR)/ck_barrier_tournament.c
+ck_barrier_tournament.o: $(Deps_ck_barrier_tournament) $(SDIR)/ck_barrier_tournament.c
 	$(CC) $(CFLAGS) -c -o $(TARGET_DIR)/ck_barrier_tournament.o $(SDIR)/ck_barrier_tournament.c
 
-ck_barrier_mcs.o: $(SDIR)/ck_barrier_mcs.c
+ck_barrier_mcs.o: $(Deps_ck_barrier_mcs) $(SDIR)/ck_barrier_mcs.c
 	$(CC) $(CFLAGS) -c -o $(TARGET_DIR)/ck_barrier_mcs.o $(SDIR)/ck_barrier_mcs.c
+
 
 clean:
 	rm -rf $(TARGET_DIR)/*.dSYM $(TARGET_DIR)/*~ $(TARGET_DIR)/*.o \


### PR DESCRIPTION
This PR fixes an issue in the Makefile.in of ck. Specifically, previously, any modifications of files like include/ck_ec_timeutil.h would not trigger a rebuild of ck_ec.o. The PR fixes this by including them as additional dependencies. This addresses https://github.com/concurrencykit/ck/issues/211.