### PR TITLE
spacing in inline asm headers

### DIFF
--- a/include/gcc/aarch64/ck_pr.h
+++ b/include/gcc/aarch64/ck_pr.h
@@ -194,7 +194,7 @@ CK_PR_STORE_S_64(double, double, "str")
         {							\
                 T previous = 0;					\
                 T tmp = 0;					\
-                __asm__ __volatile__("1:"			\
+                __asm__ __volatile__("1:\n"			\
                                      "ldxr" W " %" R "0, [%2]\n"\
                                      "neg %" R "0, %" R "0\n"	\
                                      "stxr" W " %w1, %" R "0, [%2]\n"	\

--- a/include/gcc/aarch64/ck_pr_llsc.h
+++ b/include/gcc/aarch64/ck_pr_llsc.h
@@ -37,7 +37,7 @@ ck_pr_cas_64_2_value(uint64_t target[2], uint64_t compare[2], uint64_t set[2], u
 {
         uint64_t tmp1, tmp2;
 
-        __asm__ __volatile__("1:"
+        __asm__ __volatile__("1:\n"
                              "ldxp %0, %1, [%4]\n"
                              "mov %2, %0\n"
                              "mov %3, %1\n"
@@ -71,7 +71,7 @@ ck_pr_cas_64_2(uint64_t target[2], uint64_t compare[2], uint64_t set[2])
 {
         uint64_t tmp1, tmp2;
 
-        __asm__ __volatile__("1:"
+        __asm__ __volatile__("1:\n"
                              "ldxp %0, %1, [%2]\n"
                              "eor %0, %0, %3\n"
                              "eor %1, %1, %4\n"
@@ -125,7 +125,7 @@ ck_pr_cas_ptr_2(void *target, void *compare, void *set)
                 T previous;						\
                 T tmp;							\
                 __asm__ __volatile__(					\
-                                     "1:"				\
+                                     "1:\n"				\
                                      "ldxr" W " %" R "0, [%2]\n"	\
                                      "cmp  %" R "0, %" R "4\n"		\
                                      "b.ne 2f\n"			\
@@ -166,7 +166,7 @@ CK_PR_CAS_S(char, char, "b", "w")
         {							\
                 T previous;					\
                 T tmp;						\
-                __asm__ __volatile__("1:"			\
+                __asm__ __volatile__("1:\n"			\
                                      "ldxr" W " %" R "0, [%2]\n"\
                                      "stxr" W " %w1, %" R "3, [%2]\n"\
                                      "cbnz %w1, 1b\n"		\
@@ -197,7 +197,7 @@ CK_PR_FAS(char, char, char, "b", "w")
         {							\
                 T previous = 0;					\
                 T tmp = 0;					\
-                __asm__ __volatile__("1:"			\
+                __asm__ __volatile__("1:\n"			\
                                      "ldxr" W " %" R "0, [%2]\n"\
                                       I "\n"			\
                                      "stxr" W " %w1, %" R "0, [%2]\n"	\
@@ -238,7 +238,7 @@ CK_PR_UNARY_S(char, char, "b")
         {							\
                 T previous;					\
                 T tmp;						\
-                __asm__ __volatile__("1:"			\
+                __asm__ __volatile__("1:\n"			\
                                      "ldxr" W " %" R "0, [%2]\n"\
                                       I " %" R "0, %" R "0, %" R "3\n"	\
                                      "stxr" W " %w1, %" R "0, [%2]\n"	\
@@ -285,7 +285,7 @@ ck_pr_faa_ptr(void *target, uintptr_t delta)
 {
         uintptr_t previous, r, tmp;
 
-        __asm__ __volatile__("1:"
+        __asm__ __volatile__("1:\n"
                              "ldxr %0, [%3]\n"
                              "add %1, %4, %0\n"
                              "stxr %w2, %1, [%3]\n"
@@ -305,7 +305,7 @@ ck_pr_faa_64(uint64_t *target, uint64_t delta)
 {
         uint64_t previous, r, tmp;
 
-        __asm__ __volatile__("1:"
+        __asm__ __volatile__("1:\n"
                              "ldxr %0, [%3]\n"
                              "add %1, %4, %0\n"
                              "stxr %w2, %1, [%3]\n"
@@ -325,7 +325,7 @@ ck_pr_faa_64(uint64_t *target, uint64_t delta)
         ck_pr_faa_##S(T *target, T delta)				\
         {								\
                 T previous, r, tmp;					\
-                __asm__ __volatile__("1:"				\
+                __asm__ __volatile__("1:\n"				\
                                      "ldxr" W " %w0, [%3]\n"		\
                                      "add %w1, %w4, %w0\n"		\
                                      "stxr" W " %w2, %w1, [%3]\n"	\

--- a/include/gcc/riscv64/ck_pr.h
+++ b/include/gcc/riscv64/ck_pr.h
@@ -182,7 +182,7 @@ CK_PR_STORE_S(double, double, "sd")
 	{								\
 		T previous;						\
 		int tmp;						\
-		__asm__ __volatile__("1:"				\
+		__asm__ __volatile__("1:\n"				\
 				     "li %[tmp], 1\n"			\
 				     "lr." W " %[p], %[t]\n"		\
 				     "bne %[p], %[c], 2f\n"		\
@@ -203,7 +203,7 @@ CK_PR_STORE_S(double, double, "sd")
 	{								\
 		T previous;						\
 		int tmp;						\
-		__asm__ __volatile__("1:"				\
+		__asm__ __volatile__("1:\n"				\
 				     "li %[tmp], 1\n"			\
 				     "lr." W " %[p], %[t]\n"		\
 				     "bne %[p], %[c], 2f\n"		\
@@ -413,7 +413,7 @@ CK_PR_DEC_S(int, int, "w")
 	CK_CC_INLINE static void					\
 	ck_pr_neg_##N(M *target)					\
 	{								\
-		__asm__ __volatile__("1:"				\
+		__asm__ __volatile__("1:\n"				\
 				     "lr." W " t0, %0\n"		\
 				     "sub t0, zero, t0\n"		\
 				     "sc." W " t1, t0, %0\n"		\
@@ -440,7 +440,7 @@ CK_PR_NEG_S(int, int, "w")
 	CK_CC_INLINE static void					\
 	ck_pr_not_##N(M *target)					\
 	{								\
-		__asm__ __volatile__("1:"				\
+		__asm__ __volatile__("1:\n"				\
 				     "lr." W " t0, %0\n"		\
 				     "not t0, t0\n"			\
 				     "sc." W " t1, t0, %0\n"		\


### PR DESCRIPTION
I found out that the spacing after a label definition in inline assembly at times is not consistent. 

For example, by calling CK_PR_FAS I got this inline asm code on aarch64
define internal i32 @ck_pr_fas_uint(ptr noundef %0, i32 noundef %1) #0 {
  %3 = alloca ptr, align 8
  %4 = alloca i32, align 4
  %5 = alloca i32, align 4
  %6 = alloca i32, align 4
  store ptr %0, ptr %3, align 8
  store i32 %1, ptr %4, align 4
  %7 = load ptr, ptr %3, align 8
  %8 = load i32, ptr %4, align 4
  %9 = call { i32, i32 } asm sideeffect "1:ldxr ${0:w}, [$2]\0Astxr ${1:w}, ${3:w}, [$2]\0Acbnz ${1:w}, 1b\0A", "=&r,=&r,r,r,~{memory},~{cc}"(ptr %7, i32 %8) #6, !srcloc !11
  %10 = extractvalue { i32, i32 } %9, 0
  %11 = extractvalue { i32, i32 } %9, 1
  store i32 %10, ptr %5, align 4
  store i32 %11, ptr %6, align 4
  %12 = load i32, ptr %5, align 4
  ret i32 %12
}

Whereas by adding the \n after the label definition in the ck_pr_llsc.h becomes 
define internal i32 @ck_pr_fas_uint(ptr noundef %0, i32 noundef %1) #0 {
  %3 = alloca ptr, align 8
  %4 = alloca i32, align 4
  %5 = alloca i32, align 4
  %6 = alloca i32, align 4
  store ptr %0, ptr %3, align 8
  store i32 %1, ptr %4, align 4
  %7 = load ptr, ptr %3, align 8
  %8 = load i32, ptr %4, align 4
  %9 = call { i32, i32 } asm sideeffect "1:\0Aldxr ${0:w}, [$2]\0Astxr ${1:w}, ${3:w}, [$2]\0Acbnz ${1:w}, 1b\0A", "=&r,=&r,r,r,~{memory},~{cc}"(ptr %7, i32 %8) #6, !srcloc !11
  %10 = extractvalue { i32, i32 } %9, 0
  %11 = extractvalue { i32, i32 } %9, 1
  store i32 %10, ptr %5, align 4
  store i32 %11, ptr %6, align 4
  %12 = load i32, ptr %5, align 4
  ret i32 %12
}
