### PR TITLE
more spacing after label definitions

### DIFF
--- a/include/gcc/arm/ck_pr.h
+++ b/include/gcc/arm/ck_pr.h
@@ -189,7 +189,7 @@ ck_pr_md_store_##N(const T *target, T value)			\
 {								\
 	T tmp;							\
 	uint32_t flag;						\
-	__asm __volatile("1: 		\n"			\
+	__asm __volatile("1:; 		\n"			\
 			 "ldrexd	%0, %H0, [%2]\n"	\
 			 "strexd	%1, %3, %H3, [%2]\n"	\
 			 "teq		%1, #0\n"		\
@@ -214,7 +214,7 @@ ck_pr_cas_##N##_value(T *target, T compare, T set, T *value)	\
         T previous;						\
         int tmp;						\
 								\
-	__asm__ __volatile__("1:"				\
+	__asm__ __volatile__("1:;"				\
 			     "ldrexd %0, %H0, [%4];"		\
 			     "cmp    %Q0, %Q2;"			\
 			     "ittt eq;"				\
@@ -258,7 +258,7 @@ ck_pr_cas_##N(T *target, T compare, T set)	\
 	int ret;				\
         T tmp;					\
 						\
-	__asm__ __volatile__("1:"		\
+	__asm__ __volatile__("1:;"		\
 			     "mov %0, #0;"	\
 			     "ldrexd %1, %H1, [%4];" \
 			     "cmp    %Q1, %Q2;"	\
@@ -299,7 +299,7 @@ CK_CC_INLINE static bool
 ck_pr_cas_ptr_value(void *target, void *compare, void *set, void *value)
 {
 	void *previous, *tmp;
-	__asm__ __volatile__("1:"
+	__asm__ __volatile__("1:;"
 			     "ldrex %0, [%2];"
 			     "cmp   %0, %4;"
 			     "itt eq;"
@@ -320,7 +320,7 @@ CK_CC_INLINE static bool
 ck_pr_cas_ptr(void *target, void *compare, void *set)
 {
 	void *previous, *tmp;
-	__asm__ __volatile__("1:"
+	__asm__ __volatile__("1:;"
 			     "ldrex %0, [%2];"
 			     "cmp   %0, %4;"
 			     "itt eq;"
@@ -341,7 +341,7 @@ ck_pr_cas_ptr(void *target, void *compare, void *set)
 	ck_pr_cas_##N##_value(T *target, T compare, T set, T *value)	\
 	{								\
 		T previous = 0, tmp = 0;				\
-		__asm__ __volatile__("1:"				\
+		__asm__ __volatile__("1:;"				\
 				     "ldrex" W " %0, [%2];"		\
 				     "cmp   %0, %4;"			\
 				     "itt eq;"				\
@@ -365,7 +365,7 @@ ck_pr_cas_ptr(void *target, void *compare, void *set)
 	ck_pr_cas_##N(T *target, T compare, T set)			\
 	{								\
 		T previous = 0, tmp = 0;				\
-		__asm__ __volatile__("1:"				\
+		__asm__ __volatile__("1:;"				\
 				     "ldrex" W " %0, [%2];"		\
 				     "cmp   %0, %4;"			\
 				     "itt eq;"				\
@@ -398,7 +398,7 @@ CK_PR_CAS(char, char, "b")
 	{							\
 		T previous = 0;					\
 		T tmp = 0;					\
-		__asm__ __volatile__("1:"			\
+		__asm__ __volatile__("1:;"			\
 				     "ldrex" W " %0, [%2];"	\
 				     "strex" W " %1, %3, [%2];"	\
 		    		     "cmp %1, #0;"		\
@@ -429,7 +429,7 @@ CK_PR_FAS(char, char, char, "b")
 	{							\
 		T previous = 0;					\
 		T tmp = 0;					\
-		__asm__ __volatile__("1:"			\
+		__asm__ __volatile__("1:;"			\
 				     "ldrex" W " %0, [%2];"	\
 				      I ";"			\
 				     "strex" W " %1, %0, [%2];"	\
@@ -470,7 +470,7 @@ CK_PR_UNARY_S(char, char, "b")
 	{							\
 		T previous = 0;					\
 		T tmp = 0;					\
-		__asm__ __volatile__("1:"			\
+		__asm__ __volatile__("1:;"			\
 				     "ldrex" W " %0, [%2];"	\
 				      I " %0, %0, %3;"		\
 				     "strex" W " %1, %0, [%2];"	\
@@ -513,7 +513,7 @@ ck_pr_faa_ptr(void *target, uintptr_t delta)
 {
 	uintptr_t previous, r, tmp;
 
-	__asm__ __volatile__("1:"
+	__asm__ __volatile__("1:;"
 			     "ldrex %0, [%3];"
 			     "add %1, %4, %0;"
 			     "strex %2, %1, [%3];"
@@ -534,7 +534,7 @@ ck_pr_faa_ptr(void *target, uintptr_t delta)
 	ck_pr_faa_##S(T *target, T delta)				\
 	{								\
 		T previous = 0, r = 0, tmp = 0;				\
-		__asm__ __volatile__("1:"				\
+		__asm__ __volatile__("1:;"				\
 				     "ldrex" W " %0, [%3];"		\
 				     "add %1, %4, %0;"			\
 				     "strex" W " %2, %1, [%3];"		\

--- a/include/gcc/ppc/ck_pr.h
+++ b/include/gcc/ppc/ck_pr.h
@@ -151,7 +151,7 @@ CK_PR_STORE_S(char, char, "stb")
 	ck_pr_cas_##N##_value(M *target, T compare, T set, M *value)	\
 	{								\
 		T previous;						\
-		__asm__ __volatile__("1:"				\
+		__asm__ __volatile__("1:;"				\
 				     "lwarx %0, 0, %1;"			\
 				     "cmpw  0, %0, %3;"			\
 				     "bne-  2f;"			\
@@ -170,7 +170,7 @@ CK_PR_STORE_S(char, char, "stb")
 	ck_pr_cas_##N(M *target, T compare, T set)			\
 	{								\
 		T previous;						\
-		__asm__ __volatile__("1:"				\
+		__asm__ __volatile__("1:;"				\
 				     "lwarx %0, 0, %1;"			\
 				     "cmpw  0, %0, %3;"			\
 				     "bne-  2f;"			\
@@ -199,7 +199,7 @@ CK_PR_CAS_S(int, int)
 	ck_pr_fas_##N(M *target, T v)				\
 	{							\
 		T previous;					\
-		__asm__ __volatile__("1:"			\
+		__asm__ __volatile__("1:;"			\
 				     "l" W "arx %0, 0, %1;"	\
 				     "st" W "cx. %2, 0, %1;"	\
 				     "bne- 1b;"			\
@@ -222,7 +222,7 @@ CK_PR_FAS(uint, unsigned int, unsigned int, "w")
 	ck_pr_##O##_##N(M *target)				\
 	{							\
 		T previous;					\
-		__asm__ __volatile__("1:"			\
+		__asm__ __volatile__("1:;"			\
 				     "l" W "arx %0, 0, %1;"	\
 				      I ";"			\
 				     "st" W "cx. %0, 0, %1;"	\
@@ -256,7 +256,7 @@ CK_PR_UNARY_S(int, int, "w")
 	ck_pr_##O##_##N(M *target, T delta)			\
 	{							\
 		T previous;					\
-		__asm__ __volatile__("1:"			\
+		__asm__ __volatile__("1:;"			\
 				     "l" W "arx %0, 0, %1;"	\
 				      I " %0, %2, %0;"		\
 				     "st" W "cx. %0, 0, %1;"	\
@@ -293,7 +293,7 @@ ck_pr_faa_ptr(void *target, uintptr_t delta)
 {
 	uintptr_t previous, r;
 
-	__asm__ __volatile__("1:"
+	__asm__ __volatile__("1:;"
 			     "lwarx %0, 0, %2;"
 			     "add %1, %3, %0;"
 			     "stwcx. %1, 0, %2;"
@@ -312,7 +312,7 @@ ck_pr_faa_ptr(void *target, uintptr_t delta)
 	ck_pr_faa_##S(T *target, T delta)				\
 	{								\
 		T previous, r;						\
-		__asm__ __volatile__("1:"				\
+		__asm__ __volatile__("1:;"				\
 				     "l" W "arx %0, 0, %2;"		\
 				     "add %1, %3, %0;"			\
 				     "st" W "cx. %1, 0, %2;"		\

--- a/include/gcc/ppc64/ck_pr.h
+++ b/include/gcc/ppc64/ck_pr.h
@@ -154,7 +154,7 @@ ck_pr_cas_64_value(uint64_t *target, uint64_t compare, uint64_t set, uint64_t *v
 {
 	uint64_t previous;
 
-        __asm__ __volatile__("1:"
+        __asm__ __volatile__("1:;"
 			     "ldarx %0, 0, %1;"
 			     "cmpd  0, %0, %3;"
 			     "bne-  2f;"
@@ -176,7 +176,7 @@ ck_pr_cas_ptr_value(void *target, void *compare, void *set, void *value)
 {
 	void *previous;
 
-        __asm__ __volatile__("1:"
+        __asm__ __volatile__("1:;"
 			     "ldarx %0, 0, %1;"
 			     "cmpd  0, %0, %3;"
 			     "bne-  2f;"
@@ -198,7 +198,7 @@ ck_pr_cas_64(uint64_t *target, uint64_t compare, uint64_t set)
 {
 	uint64_t previous;
 
-        __asm__ __volatile__("1:"
+        __asm__ __volatile__("1:;"
 			     "ldarx %0, 0, %1;"
 			     "cmpd  0, %0, %3;"
 			     "bne-  2f;"
@@ -219,7 +219,7 @@ ck_pr_cas_ptr(void *target, void *compare, void *set)
 {
 	void *previous;
 
-        __asm__ __volatile__("1:"
+        __asm__ __volatile__("1:;"
 			     "ldarx %0, 0, %1;"
 			     "cmpd  0, %0, %3;"
 			     "bne-  2f;"
@@ -240,7 +240,7 @@ ck_pr_cas_ptr(void *target, void *compare, void *set)
 	ck_pr_cas_##N##_value(T *target, T compare, T set, T *value)	\
 	{								\
 		T previous;						\
-		__asm__ __volatile__("1:"				\
+		__asm__ __volatile__("1:;"				\
 				     "lwarx %0, 0, %1;"			\
 				     "cmpw  0, %0, %3;"			\
 				     "bne-  2f;"			\
@@ -259,7 +259,7 @@ ck_pr_cas_ptr(void *target, void *compare, void *set)
 	ck_pr_cas_##N(T *target, T compare, T set)			\
 	{								\
 		T previous;						\
-		__asm__ __volatile__("1:"				\
+		__asm__ __volatile__("1:;"				\
 				     "lwarx %0, 0, %1;"			\
 				     "cmpw  0, %0, %3;"			\
 				     "bne-  2f;"			\
@@ -285,7 +285,7 @@ CK_PR_CAS(int, int)
 	ck_pr_fas_##N(M *target, T v)				\
 	{							\
 		T previous;					\
-		__asm__ __volatile__("1:"			\
+		__asm__ __volatile__("1:;"			\
 				     "l" W "arx %0, 0, %1;"	\
 				     "st" W "cx. %2, 0, %1;"	\
 				     "bne- 1b;"			\
@@ -312,7 +312,7 @@ CK_PR_FAS(uint, unsigned int, unsigned int, "w")
 	ck_pr_##O##_##N(M *target)				\
 	{							\
 		T previous;					\
-		__asm__ __volatile__("1:"			\
+		__asm__ __volatile__("1:;"			\
 				     "l" W "arx %0, 0, %1;"	\
 				      I ";"			\
 				     "st" W "cx. %0, 0, %1;"	\
@@ -347,7 +347,7 @@ CK_PR_UNARY_S(int, int, "w")
 	ck_pr_##O##_##N(M *target, T delta)			\
 	{							\
 		T previous;					\
-		__asm__ __volatile__("1:"			\
+		__asm__ __volatile__("1:;"			\
 				     "l" W "arx %0, 0, %1;"	\
 				      I " %0, %2, %0;"		\
 				     "st" W "cx. %0, 0, %1;"	\
@@ -385,7 +385,7 @@ ck_pr_faa_ptr(void *target, uintptr_t delta)
 {
 	uintptr_t previous, r;
 
-	__asm__ __volatile__("1:"
+	__asm__ __volatile__("1:;"
 			     "ldarx %0, 0, %2;"
 			     "add %1, %3, %0;"
 			     "stdcx. %1, 0, %2;"
@@ -404,7 +404,7 @@ ck_pr_faa_ptr(void *target, uintptr_t delta)
 	ck_pr_faa_##S(T *target, T delta)				\
 	{								\
 		T previous, r;						\
-		__asm__ __volatile__("1:"				\
+		__asm__ __volatile__("1:;"				\
 				     "l" W "arx %0, 0, %2;"		\
 				     "add %1, %3, %0;"			\
 				     "st" W "cx. %1, 0, %2;"		\


### PR DESCRIPTION
Following [#244](https://github.com/concurrencykit/ck/pull/244)
I have noted that also for armv7 and ppc the inline asm generated does not have the proper formatting, so I have added them 
 An example would be 
 "1:ldrex $0, [$2];cmp   $0, $4;itt eq;strexeq $1, $3, [$2];cmpeq   $1, #1;beq   1b;", "=&r,=&r,r,r,r,0,1,~{memory},~{cc}"
 
 Which now has the extra divider ";" after the label definition.
"1:;ldrex $0, [$2];cmp   $0, $4;itt eq;strexeq $1, $3, [$2];cmpeq   $1, #1;beq   1b;", "=&r,=&r,r,r,r,0,1,~{memory},~{cc}"

Hope this helps!