### PR TITLE
ck_pr: fix type of pointer atomics

### DIFF
--- a/include/gcc/ck_pr.h
+++ b/include/gcc/ck_pr.h
@@ -218,7 +218,7 @@ CK_PR_CAS_O(8,  uint8_t)
 		return (d);					\
 	}
 
-CK_PR_FAA(ptr, void, void *)
+CK_PR_FAA(ptr, void, uintptr_t)
 
 #define CK_PR_FAA_S(S, T) CK_PR_FAA(S, T, T)
 
@@ -282,7 +282,7 @@ CK_PR_GENERATE(xor)
 
 #define CK_PR_UNARY_S(S, M) CK_PR_UNARY(S, M, M)
 
-CK_PR_UNARY(ptr, void, void *)
+CK_PR_UNARY(ptr, void, uintptr_t)
 CK_PR_UNARY_S(char, char)
 CK_PR_UNARY_S(int, int)
 CK_PR_UNARY_S(uint, unsigned int)

--- a/include/gcc/riscv64/ck_pr.h
+++ b/include/gcc/riscv64/ck_pr.h
@@ -310,7 +310,7 @@ CK_PR_FAS_S(uint, unsigned int, "w")
 	}
 #define CK_PR_ADD_S(N, T, W)	CK_PR_ADD(N, T, T, T, W)
 
-CK_PR_ADD(ptr, void, void *, uint64_t, "d")
+CK_PR_ADD(ptr, void, uintptr_t, uint64_t, "d")
 CK_PR_ADD_S(64, uint64_t, "d")
 CK_PR_ADD_S(32, uint32_t, "w")
 CK_PR_ADD_S(uint, unsigned int, "w")
@@ -338,7 +338,7 @@ CK_PR_ADD_S(int, int, "w")
 	}
 #define CK_PR_INC_S(N, T, W)	CK_PR_INC(N, T, T, W)
 
-CK_PR_INC(ptr, void, void *, "d")
+CK_PR_INC(ptr, void, uintptr_t, "d")
 CK_PR_INC_S(64, uint64_t, "d")
 CK_PR_INC_S(32, uint32_t, "w")
 CK_PR_INC_S(uint, unsigned int, "w")
@@ -372,7 +372,7 @@ CK_PR_INC_S(int, int, "w")
 	}
 #define CK_PR_SUB_S(N, T, W)	CK_PR_SUB(N, T, T, T, W)
 
-CK_PR_SUB(ptr, void, void *, uint64_t, "d")
+CK_PR_SUB(ptr, void, uintptr_t, uint64_t, "d")
 CK_PR_SUB_S(64, uint64_t, "d")
 CK_PR_SUB_S(32, uint32_t, "w")
 CK_PR_SUB_S(uint, unsigned int, "w")
@@ -397,7 +397,7 @@ CK_PR_SUB_S(int, int, "w")
 	}
 #define CK_PR_DEC_S(N, T, W)	CK_PR_DEC(N, T, T, W)
 
-CK_PR_DEC(ptr, void, void *, "d")
+CK_PR_DEC(ptr, void, uintptr_t, "d")
 CK_PR_DEC_S(64, uint64_t, "d")
 CK_PR_DEC_S(32, uint32_t, "w")
 CK_PR_DEC_S(uint, unsigned int, "w")

--- a/include/gcc/s390x/ck_pr.h
+++ b/include/gcc/s390x/ck_pr.h
@@ -272,7 +272,7 @@ ck_pr_fas_double(double *target, double *v)
 #define CK_PR_BINARY_S(K, S, T) CK_PR_BINARY(K, S, T, T)
 
 #define CK_PR_GENERATE(K)			\
-	CK_PR_BINARY(K, ptr, void, void *)	\
+	CK_PR_BINARY(K, ptr, void, uintptr_t)	\
 	CK_PR_BINARY_S(K, char, char)		\
 	CK_PR_BINARY_S(K, int, int)		\
 	CK_PR_BINARY_S(K, uint, unsigned int)	\
@@ -330,7 +330,7 @@ CK_PR_GENERATE(xor)
 #define CK_PR_UNARY_S(S, M) CK_PR_UNARY(S, M, M) \
 			    CK_PR_UNARY_X(S, M)
 
-CK_PR_UNARY(ptr, void, void *)
+CK_PR_UNARY(ptr, void, uintptr_t)
 CK_PR_UNARY_S(char, char)
 CK_PR_UNARY_S(int, int)
 CK_PR_UNARY_S(uint, unsigned int)


### PR DESCRIPTION
Adding two pointers does not make sense, all arithmetic operations on
pointers use uintptr_t as the other operand.
